### PR TITLE
Fix tooltip

### DIFF
--- a/src/components/Tooltip/__snapshots__/index.test.jsx.snap
+++ b/src/components/Tooltip/__snapshots__/index.test.jsx.snap
@@ -2,123 +2,63 @@
 
 exports[`StyledATag storybook example renders 1`] = `
 .c2 {
-  color: #000;
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c6 {
-  font-size: 1.125rem;
-  font-weight: 400;
-  line-height: 1.4;
-  font-family: RT-Alias-Grotesk;
-  text-align: left;
-  display: block;
-  margin: 0;
-}
-
-.c0 {
-  min-width: 0;
-  box-sizing: border-box;
-  position: relative;
-  margin-left: 8px;
-  margin-right: 8px;
+  width: 2em;
+  height: 2em;
+  padding: 0;
+  line-height: 2em;
+  border-radius: 1em;
+  border: 1px solid var(--black);
+  color: var(--black);
+  background: transparent;
+  text-align: center;
+  cursor: pointer;
 }
 
 .c4 {
-  min-width: 0;
-  box-sizing: border-box;
-  border-radius: 16px;
-  padding: 8px;
-}
-
-.c5 {
-  position: absolute;
   display: none;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
+  position: absolute;
+  top: calc(100% + 0.5em);
+  left: 50%;
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  max-width: 200px;
-  left: 50%;
+  max-width: 20em;
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
-  bottom: -48px;
-  padding: 8px;
-  color: #262626;
-  background-color: #ffffff;
+  padding: 0.5em 0.75em;
+  color: var(--black);
+  background-color: var(--white);
   border-radius: 4px;
   box-shadow: rgba(0,0,0,0.10) 0px 0.7px 2.2px -8px,rgba(0,0,0,0.04) 0px 1.7px 2.4px,rgba(0,0,0,0.106) 0px 3.1px 8.1px,rgba(0,0,0,0.04) 0px 5.6px 12.1px,rgba(0,0,0,0.045) 0px 4.4px 4.8px,rgba(0,0,0,0.05) 0px 15px 41px;
   z-index: 9;
-  -webkit-transition: 0.24s ease-in-out;
-  transition: 0.24s ease-in-out;
 }
 
-.c1 {
+.c0 {
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  background-color: transparent;
-  border-radius: 100px;
-  border: 1px solid;
-  width: 24px;
-  height: 24px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  cursor: pointer;
-  -webkit-transition: 0.24s ease-in-out;
-  transition: 0.24s ease-in-out;
-  color: #000;
 }
 
-.c1:hover ~ .c3 {
+.c0:hover .c1 {
+  color: var(--purple-medium);
+  border-color: var(--purple-medium);
+}
+
+.c0:hover .c3 {
   display: block;
 }
 
 <div
   class="c0"
 >
-  <a
-    aria-label="Tooltip"
-    class="c1"
-    color="core.black"
+  <button
+    class="c1 c2"
   >
-    <p
-      class="c2"
-      color="core.black"
-      font-family="RT-Alias-Grotesk"
-      font-size="2"
-      font-weight="400"
-    >
-      ?
-    </p>
-  </a>
+    ?
+  </button>
   <div
-    class="c3 c4 c5"
+    class="c3 c4"
   >
-    <p
-      class="c6"
-      display="block"
-      font-family="RT-Alias-Grotesk"
-      font-size="2"
-      font-weight="400"
-    >
-      tooltip content
-    </p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec est ultrices, posuere lorem a, convallis quam. Etiam venenatis velit.
   </div>
 </div>
 `;

--- a/src/components/Tooltip/index.stories.jsx
+++ b/src/components/Tooltip/index.stories.jsx
@@ -20,6 +20,7 @@ const Template = args => <Tooltip {...args} />
 
 export const Base = Template.bind({})
 Base.args = {
-  content: 'tooltip content',
+  content:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec est ultrices, posuere lorem a, convallis quam. Etiam venenatis velit.',
   color: 'core.black'
 }

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,91 +1,64 @@
 import styled from 'styled-components'
-import { color as styledColor, border } from 'styled-system'
-import { string } from 'prop-types'
-import { Text } from '../Typography'
-import Box from '../Box'
+import PropTypes from 'prop-types'
 
-const TooltipContent = styled(Box)`
-  position: absolute;
+const Icon = styled.button`
+  width: 2em;
+  height: 2em;
+  padding: 0;
+  line-height: 2em;
+  border-radius: 1em;
+  border: 1px solid var(--black);
+  color: var(--black);
+  background: transparent;
+  text-align: center;
+  cursor: pointer;
+`
+
+const Content = styled.div`
   display: none;
-  height: fit-content;
-  width: max-content;
-  max-width: 200px;
+  position: absolute;
+  top: calc(100% + 0.5em);
   left: 50%;
+  width: max-content;
+  max-width: 20em;
   transform: translateX(-50%);
-  bottom: -48px;
-  padding: ${props => props.theme.sizes[2]}px;
-  color: ${props => props.theme.colors.core.nearblack};
-  background-color: ${props => props.theme.colors.core.white};
+  padding: 0.5em 0.75em;
+  color: var(--black);
+  background-color: var(--white);
   border-radius: ${props => props.theme.radii[2]};
   box-shadow: ${props => props.theme.shadows[2]};
   z-index: ${props => props.theme.zIndices[1]};
-  transition: 0.24s ease-in-out;
-  ${styledColor}
 `
 
-const TooltipContainer = styled.a`
+const Wrapper = styled.div`
   position: relative;
-  display: flex;
-  background-color: transparent;
-  border-radius: ${props => props.theme.radii[6]};
-  border: 1px solid;
-  width: 24px;
-  height: 24px;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: 0.24s ease-in-out;
-  ${styledColor}
-  ${border}
 
- &:hover ~ ${TooltipContent} {
-    display: block;
-  }
-
-  /* Paired with the ontouchstart declaration inside the TooltipContent markup, this is intended to enable touch devices to trigger the tooltip, too. While we don't support touch devices at launch, we may do so in the future. Ref: https://stackoverflow.com/a/37150472/2839730 */
-
-  /* &:active {
-    ${TooltipContent} {
-      opacity: 1;
+  &:hover {
+    ${Icon} {
+      color: var(--purple-medium);
+      border-color: var(--purple-medium);
+    }
+    ${Content} {
+      display: block;
     }
   }
-
-  &:focus {
-    ${TooltipContent} {
-      opacity: 1;
-    }
-  } */
 `
 
-const Tooltip = ({
-  content,
-  color,
-  ...props
-}: Partial<{ content: string; color: string; [x: string]: any }>) => {
+const Tooltip = ({ content }: TooltipProps) => {
   return (
-    <Box position='relative' mx={2}>
-      <TooltipContainer color={color} aria-label='Tooltip' {...props}>
-        <Text m={0} color={color}>
-          ?
-        </Text>
-      </TooltipContainer>
-
-      <TooltipContent ontouchstart p={2} borderRadius={4}>
-        <Text textAlign='left' display='block' m={0}>
-          {content}
-        </Text>
-      </TooltipContent>
-    </Box>
+    <Wrapper>
+      <Icon>?</Icon>
+      <Content>{content}</Content>
+    </Wrapper>
   )
 }
 
-Tooltip.propTypes = {
-  content: string.isRequired,
-  color: string
+interface TooltipProps {
+  content: string
 }
 
-Tooltip.defaultProps = {
-  color: 'core.black'
+Tooltip.propTypes = {
+  content: PropTypes.string.isRequired
 }
 
 export default Tooltip


### PR DESCRIPTION
Fixed tooltip bug and made it look a bit nicer.

Removed the option to pass a custom color right now, since it doesn't seem useful at the moment, would be better to have a pre-selection of colors like for `ButtonV2`.

Can't find any occurence of the Tooltip right now, other than the storybook.

What might still be an issue, is that part of the tooltip content can be rendered off-screen when it's placed near the edge of the viewport. Ideally it should choose a position (left/right) after render, depending on the distance from the viewport edge.