### PR TITLE
Badge text uppercase

### DIFF
--- a/src/components/HistoryTables/MessageHistory/Detail.tsx
+++ b/src/components/HistoryTables/MessageHistory/Detail.tsx
@@ -146,7 +146,7 @@ export default function MessageDetail(props: MessageDetailProps) {
           <Line label='Transaction Fee'>{pending ? 'Pending' : totalCost}</Line>
           {!loading && methodName && (
             <Line label='Method'>
-              <Badge color='purple'>{methodName.toUpperCase()}</Badge>
+              <Badge color='purple' text={methodName} />
             </Line>
           )}
           <HR />

--- a/src/components/HistoryTables/MessageHistory/MessageConfirmedRow.tsx
+++ b/src/components/HistoryTables/MessageHistory/MessageConfirmedRow.tsx
@@ -51,7 +51,7 @@ export default function MessageHistoryRow(props: MessageHistoryRowProps) {
         </Link>
       </TD>
       <TD>
-        <Badge color='purple'>{methodName.toUpperCase()}</Badge>
+        <Badge color='purple' text={methodName} />
       </TD>
       <TD>{message.height}</TD>
       <TD>{age}</TD>
@@ -65,9 +65,10 @@ export default function MessageHistoryRow(props: MessageHistoryRowProps) {
       </TD>
       {props.inspectingAddress && (
         <TD>
-          <Badge color={toAddressIsInspecting ? 'green' : 'yellow'}>
-            {toAddressIsInspecting ? 'IN' : 'OUT'}
-          </Badge>
+          <Badge
+            color={toAddressIsInspecting ? 'green' : 'yellow'}
+            text={toAddressIsInspecting ? 'IN' : 'OUT'}
+          />
         </TD>
       )}
       <TD>

--- a/src/components/HistoryTables/MessageHistory/MessagePendingRow.tsx
+++ b/src/components/HistoryTables/MessageHistory/MessagePendingRow.tsx
@@ -51,7 +51,7 @@ export default function PendingMessageHistoryRow(
       </TD>
       {props.inspectingAddress && (
         <TD>
-          <Badge color='purple'>{methodName.toUpperCase()}</Badge>
+          <Badge color='purple' text={methodName} />
         </TD>
       )}
       <TD>(Pending)</TD>
@@ -65,9 +65,10 @@ export default function PendingMessageHistoryRow(
         />
       </TD>
       <TD>
-        <Badge color={toAddressIsInspecting ? 'green' : 'yellow'}>
-          {toAddressIsInspecting ? 'IN' : 'OUT'}
-        </Badge>
+        <Badge
+          color={toAddressIsInspecting ? 'green' : 'yellow'}
+          text={toAddressIsInspecting ? 'IN' : 'OUT'}
+        />
       </TD>
       <TD>
         <AddressLink

--- a/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
+++ b/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
@@ -46,9 +46,10 @@ export default function ProposalHistoryRow(props: ProposalHistoryRowProps) {
         <SmartLink href={idHref(proposal.id)}>{proposal.id}</SmartLink>
       </TD>
       <TD>
-        <Badge color='purple'>
-          {getMethodName('/multisig', proposal.method).toUpperCase()}
-        </Badge>
+        <Badge
+          color='purple'
+          text={getMethodName('/multisig', proposal.method)}
+        />
       </TD>
       <TD>
         <AddressLink

--- a/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
+++ b/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
@@ -47,7 +47,7 @@ export default function ProposalHistoryRow(props: ProposalHistoryRowProps) {
       </TD>
       <TD>
         <Badge color='purple'>
-          {getMethodName('/multisig', proposal.method)}
+          {getMethodName('/multisig', proposal.method).toUpperCase()}
         </Badge>
       </TD>
       <TD>

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -237,9 +237,10 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
         case 'method': {
           return (
             <Line key={`${depth}-${key}`} label={key} depth={depth}>
-              <Badge color='purple'>
-                {getMethodName(actorName, value as number).toUpperCase()}
-              </Badge>
+              <Badge
+                color='purple'
+                text={getMethodName(actorName, value as number)}
+              />
             </Line>
           )
         }
@@ -337,18 +338,19 @@ export const Status = ({ exitCode, pending }: StatusProps) => {
     return 'red'
   }, [success, pending])
 
-  const statusText = useMemo(() => {
+  const text = useMemo(() => {
     if (pending) return 'PENDING'
     if (success) return 'SUCCESS'
     return 'ERROR'
   }, [success, pending])
-  return (
-    <Badge color={color}>
-      {success && <IconCheck width='1.1875rem' />}
-      {pending && <IconPending />}
-      {statusText}
-    </Badge>
-  )
+
+  const icon = useMemo(() => {
+    if (pending) return <IconPending />
+    if (success) return <IconCheck width='1.1875rem' />
+    return null
+  }, [success, pending])
+
+  return <Badge color={color} text={text} icon={icon} />
 }
 
 type StatusProps = {
@@ -367,10 +369,12 @@ Status.propTypes = {
 export const Confirmations = ({ count, total }: ConfirmationsProps) => {
   const confirmed = useMemo(() => count >= total, [count, total])
   return (
-    <Badge color={confirmed ? 'green' : 'yellow'}>
-      {confirmed && <IconCheck width='1.1875rem' />}
-      {Math.min(count, total)} / {total} Confirmations
-    </Badge>
+    <Badge
+      color={confirmed ? 'green' : 'yellow'}
+      text={`${Math.min(count, total)} / ${total} Confirmations`}
+      icon={confirmed ? <IconCheck width='1.1875rem' /> : null}
+      uppercase={false}
+    />
   )
 }
 

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -238,7 +238,7 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
           return (
             <Line key={`${depth}-${key}`} label={key} depth={depth}>
               <Badge color='purple'>
-                {getMethodName(actorName, value as number)}
+                {getMethodName(actorName, value as number).toUpperCase()}
               </Badge>
             </Line>
           )

--- a/src/components/HistoryTables/generic.tsx
+++ b/src/components/HistoryTables/generic.tsx
@@ -7,7 +7,7 @@ export const Title = styled.h2`
   color: var(--purple-medium);
 `
 
-export const Badge = ({ color, children }: BadgeProps) => (
+export const Badge = ({ color, text, uppercase, icon }: BadgeProps) => (
   <Box
     display='inline-flex'
     alignItems='center'
@@ -21,17 +21,26 @@ export const Badge = ({ color, children }: BadgeProps) => (
     style={{ whiteSpace: 'nowrap' }}
     textAlign='center'
   >
-    {children}
+    {icon}
+    <span>{uppercase ? text.toUpperCase() : text}</span>
   </Box>
 )
 
 type BadgeProps = {
   color: 'purple' | 'green' | 'yellow' | 'red' | 'gray'
-  children: React.ReactNode
+  text: string
+  uppercase: boolean
+  icon?: JSX.Element
 }
 
 Badge.propTypes = {
-  color: PropTypes.oneOf(['purple', 'green', 'yellow', 'red', 'gray'])
-    .isRequired,
-  children: PropTypes.node.isRequired
+  color: PropTypes.oneOf(['purple', 'green', 'yellow', 'red', 'gray']),
+  text: PropTypes.string.isRequired,
+  uppercase: PropTypes.bool,
+  icon: PropTypes.node
+}
+
+Badge.defaultProps = {
+  color: 'gray',
+  uppercase: true
 }

--- a/src/components/HistoryTables/generic.tsx
+++ b/src/components/HistoryTables/generic.tsx
@@ -29,14 +29,14 @@ export const Badge = ({ color, text, uppercase, icon }: BadgeProps) => (
 type BadgeProps = {
   color: 'purple' | 'green' | 'yellow' | 'red' | 'gray'
   text: string
-  uppercase: boolean
+  uppercase?: boolean
   icon?: JSX.Element
 }
 
 Badge.propTypes = {
   color: PropTypes.oneOf(['purple', 'green', 'yellow', 'red', 'gray']),
   text: PropTypes.string.isRequired,
-  uppercase?: PropTypes.bool,
+  uppercase: PropTypes.bool,
   icon: PropTypes.node
 }
 

--- a/src/components/HistoryTables/generic.tsx
+++ b/src/components/HistoryTables/generic.tsx
@@ -36,7 +36,7 @@ type BadgeProps = {
 Badge.propTypes = {
   color: PropTypes.oneOf(['purple', 'green', 'yellow', 'red', 'gray']),
   text: PropTypes.string.isRequired,
-  uppercase: PropTypes.bool,
+  uppercase?: PropTypes.bool,
   icon: PropTypes.node
 }
 


### PR DESCRIPTION
Badge text will now be uppercased by default, unless `uppercase=false` is passed, for example for the confirmation:

![image](https://user-images.githubusercontent.com/394452/158642419-30164b03-76ee-4af9-ad8a-5b71550e99d8.png)
