### PR TITLE
Fix inspecting address checks

### DIFF
--- a/src/components/HistoryTables/MessageHistory/MessageConfirmedRow.tsx
+++ b/src/components/HistoryTables/MessageHistory/MessageConfirmedRow.tsx
@@ -10,7 +10,7 @@ import { attoFilToFil } from '../utils'
 import { ChainHeadSubscription } from '../../../generated/graphql'
 import { useAge } from './useAge'
 import { useMethodName } from './useMethodName'
-import convertAddrToPrefix from '../../../utils/convertAddrToPrefix'
+import { isAddrEqual } from '../../../utils/isAddrEqual'
 
 export default function MessageHistoryRow(props: MessageHistoryRowProps) {
   const { message, cidHref, inspectingAddress } = props
@@ -18,17 +18,11 @@ export default function MessageHistoryRow(props: MessageHistoryRowProps) {
 
   const value = useMemo(() => attoFilToFil(message.value), [message.value])
   const fromAddressIsInspecting = useMemo(
-    () =>
-      message.from.robust === inspectingAddress ||
-      message.from.id === inspectingAddress,
+    () => isAddrEqual(message.from, inspectingAddress),
     [message.from, inspectingAddress]
   )
   const toAddressIsInspecting = useMemo(
-    () =>
-      convertAddrToPrefix(message.to.robust) ===
-        convertAddrToPrefix(inspectingAddress) ||
-      convertAddrToPrefix(message.to.id) ===
-        convertAddrToPrefix(inspectingAddress),
+    () => isAddrEqual(message.to, inspectingAddress),
     [message.to, inspectingAddress]
   )
   const { methodName } = useMethodName(message)

--- a/src/components/HistoryTables/MessageHistory/MessagePendingRow.tsx
+++ b/src/components/HistoryTables/MessageHistory/MessagePendingRow.tsx
@@ -9,7 +9,7 @@ import { TR, TD } from '../table'
 import { AddressLink } from '../../AddressLink'
 import { MessagePendingRow, MESSAGE_PENDING_ROW_PROP_TYPE } from '../types'
 import { useMethodName } from './useMethodName'
-import convertAddrToPrefix from '../../../utils/convertAddrToPrefix'
+import { isAddrEqual } from '../../../utils/isAddrEqual'
 
 // add RelativeTime plugin to Day.js
 dayjs.extend(relativeTime.default)
@@ -19,17 +19,11 @@ export default function PendingMessageHistoryRow(
 ) {
   const { message, cidHref, inspectingAddress } = props
   const fromAddressIsInspecting = useMemo(
-    () =>
-      message.from.robust === inspectingAddress ||
-      message.from.id === inspectingAddress,
+    () => isAddrEqual(message.from, inspectingAddress),
     [message.from, inspectingAddress]
   )
   const toAddressIsInspecting = useMemo(
-    () =>
-      convertAddrToPrefix(message.to.robust) ===
-        convertAddrToPrefix(inspectingAddress) ||
-      convertAddrToPrefix(message.to.id) ===
-        convertAddrToPrefix(inspectingAddress),
+    () => isAddrEqual(message.to, inspectingAddress),
     [message.to, inspectingAddress]
   )
   const { methodName } = useMethodName({ ...message, actorName: '' })
@@ -60,7 +54,7 @@ export default function PendingMessageHistoryRow(
         <AddressLink
           id={message.from.robust ? '' : message.from.id}
           address={message.from.robust}
-          disableLink={!fromAddressIsInspecting}
+          disableLink={fromAddressIsInspecting}
           hideCopy
         />
       </TD>

--- a/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
+++ b/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
@@ -9,6 +9,7 @@ import { TR, TD } from '../table'
 import { AddressLink } from '../../AddressLink'
 import { SmartLink } from '../../Link/SmartLink'
 import { MsigTransaction } from '../../../generated/graphql'
+import { isAddrEqual } from '../../../utils/isAddrEqual'
 import { PROPOSAL_ROW_PROP_TYPE } from '../types'
 import { getMethodName } from '../methodName'
 import appTheme from '../../theme'
@@ -21,9 +22,7 @@ export default function ProposalHistoryRow(props: ProposalHistoryRowProps) {
 
   const router = useRouter()
   const proposerIsInspecting = useMemo(
-    () =>
-      proposal.approved[0].robust === inspectingAddress ||
-      proposal.approved[0].id === inspectingAddress,
+    () => isAddrEqual(proposal.approved[0], inspectingAddress),
     [proposal.approved, inspectingAddress]
   )
 


### PR DESCRIPTION
The only thing that was really necessary was to remove the exclamation mark from:
```
disableLink={!fromAddressIsInspecting}
```

But I thought it might be better / nicer to use the `isAddrEqual` utility for comparing the addresses