### PR TITLE
Make custom proptypes requirable

### DIFF
--- a/src/components/AccountCard/index.jsx
+++ b/src/components/AccountCard/index.jsx
@@ -1,5 +1,5 @@
 import { string, func, bool, oneOf } from 'prop-types'
-import { ADDRESS_PROPTYPE_REQUIRED } from '../../customPropTypes'
+import { ADDRESS_PROPTYPE } from '../../customPropTypes'
 import Box from '../Box'
 import Glyph from '../Glyph'
 import Button from '../Button'
@@ -81,7 +81,7 @@ AccountCard.propTypes = {
   /**
    * Filecoin address
    */
-  address: ADDRESS_PROPTYPE_REQUIRED,
+  address: ADDRESS_PROPTYPE.isRequired,
   /**
    * Sets background-color of the card
    */

--- a/src/components/AccountCard/index.jsx
+++ b/src/components/AccountCard/index.jsx
@@ -1,5 +1,5 @@
 import { string, func, bool, oneOf } from 'prop-types'
-import { ADDRESS_PROPTYPE } from '../../customPropTypes'
+import { ADDRESS_PROPTYPE_REQUIRED } from '../../customPropTypes'
 import Box from '../Box'
 import Glyph from '../Glyph'
 import Button from '../Button'
@@ -81,7 +81,7 @@ AccountCard.propTypes = {
   /**
    * Filecoin address
    */
-  address: ADDRESS_PROPTYPE,
+  address: ADDRESS_PROPTYPE_REQUIRED,
   /**
    * Sets background-color of the card
    */

--- a/src/components/AccountCardAlt/index.jsx
+++ b/src/components/AccountCardAlt/index.jsx
@@ -3,7 +3,7 @@ import useSWR from 'swr'
 import LotusRPCEngine from '@glif/filecoin-rpc-client'
 import { FilecoinNumber } from '@glif/filecoin-number'
 import { string, number, bool, func } from 'prop-types'
-import { ADDRESS_PROPTYPE_REQUIRED } from '../../customPropTypes'
+import { ADDRESS_PROPTYPE } from '../../customPropTypes'
 import Box from '../Box'
 import Glyph from '../Glyph'
 import Card from '../Card'
@@ -123,7 +123,7 @@ const AccountCardAlt = ({
 }
 
 AccountCardAlt.propTypes = {
-  address: ADDRESS_PROPTYPE_REQUIRED,
+  address: ADDRESS_PROPTYPE.isRequired,
   index: number.isRequired,
   path: string.isRequired,
   balance: string,

--- a/src/components/AccountCardAlt/index.jsx
+++ b/src/components/AccountCardAlt/index.jsx
@@ -3,7 +3,7 @@ import useSWR from 'swr'
 import LotusRPCEngine from '@glif/filecoin-rpc-client'
 import { FilecoinNumber } from '@glif/filecoin-number'
 import { string, number, bool, func } from 'prop-types'
-import { ADDRESS_PROPTYPE } from '../../customPropTypes'
+import { ADDRESS_PROPTYPE_REQUIRED } from '../../customPropTypes'
 import Box from '../Box'
 import Glyph from '../Glyph'
 import Card from '../Card'
@@ -123,7 +123,7 @@ const AccountCardAlt = ({
 }
 
 AccountCardAlt.propTypes = {
-  address: ADDRESS_PROPTYPE,
+  address: ADDRESS_PROPTYPE_REQUIRED,
   index: number.isRequired,
   path: string.isRequired,
   balance: string,

--- a/src/components/BalanceCard/index.jsx
+++ b/src/components/BalanceCard/index.jsx
@@ -3,7 +3,7 @@ import { func, bool } from 'prop-types'
 import Box from '../Box'
 import Button from '../Button'
 import { Num, Label } from '../Typography'
-import { FILECOIN_NUMBER_PROPTYPE_REQUIRED } from '../../customPropTypes'
+import { FILECOIN_NUMBER_PROPTYPE } from '../../customPropTypes'
 import makeFriendlyBalance from '../../utils/makeFriendlyBalance'
 import ApproximationToggleBtn from './ApproximationToggleBtn'
 
@@ -75,7 +75,7 @@ BalanceCard.propTypes = {
   /**
    * users balance in Filecoin denom
    */
-  balance: FILECOIN_NUMBER_PROPTYPE_REQUIRED,
+  balance: FILECOIN_NUMBER_PROPTYPE.isRequired,
   /**
    * action fired when send button is clicked
    */

--- a/src/components/BalanceCard/index.jsx
+++ b/src/components/BalanceCard/index.jsx
@@ -3,7 +3,7 @@ import { func, bool } from 'prop-types'
 import Box from '../Box'
 import Button from '../Button'
 import { Num, Label } from '../Typography'
-import { FILECOIN_NUMBER_PROP } from '../../customPropTypes'
+import { FILECOIN_NUMBER_PROPTYPE_REQUIRED } from '../../customPropTypes'
 import makeFriendlyBalance from '../../utils/makeFriendlyBalance'
 import ApproximationToggleBtn from './ApproximationToggleBtn'
 
@@ -75,7 +75,7 @@ BalanceCard.propTypes = {
   /**
    * users balance in Filecoin denom
    */
-  balance: FILECOIN_NUMBER_PROP,
+  balance: FILECOIN_NUMBER_PROPTYPE_REQUIRED,
   /**
    * action fired when send button is clicked
    */

--- a/src/components/Copy/index.jsx
+++ b/src/components/Copy/index.jsx
@@ -2,7 +2,7 @@ import { string } from 'prop-types'
 import Box from '../Box'
 import { Title as AccountAddress } from '../Typography'
 import truncate from '../../utils/truncateAddress'
-import { ADDRESS_PROPTYPE } from '../../customPropTypes'
+import { ADDRESS_PROPTYPE_REQUIRED } from '../../customPropTypes'
 import { CopyText } from './CopyText'
 
 export * from './CopyText'
@@ -25,7 +25,7 @@ export const CopyAddress = ({ address, ...props }) => {
 }
 
 CopyAddress.propTypes = {
-  address: ADDRESS_PROPTYPE,
+  address: ADDRESS_PROPTYPE_REQUIRED,
   color: string
 }
 

--- a/src/components/Copy/index.jsx
+++ b/src/components/Copy/index.jsx
@@ -2,7 +2,7 @@ import { string } from 'prop-types'
 import Box from '../Box'
 import { Title as AccountAddress } from '../Typography'
 import truncate from '../../utils/truncateAddress'
-import { ADDRESS_PROPTYPE_REQUIRED } from '../../customPropTypes'
+import { ADDRESS_PROPTYPE } from '../../customPropTypes'
 import { CopyText } from './CopyText'
 
 export * from './CopyText'
@@ -25,7 +25,7 @@ export const CopyAddress = ({ address, ...props }) => {
 }
 
 CopyAddress.propTypes = {
-  address: ADDRESS_PROPTYPE_REQUIRED,
+  address: ADDRESS_PROPTYPE.isRequired,
   color: string
 }
 

--- a/src/components/HistoryTables/MessageHistory/index.tsx
+++ b/src/components/HistoryTables/MessageHistory/index.tsx
@@ -4,7 +4,7 @@ import Box from '../../Box'
 import MessageConfirmedRow from './MessageConfirmedRow'
 import MessagePendingRow from './MessagePendingRow'
 import { MessageRowColumnTitles } from './MessageRowColumnTitles'
-import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+import { ADDRESS_PROPTYPE_REQUIRED } from '../../../customPropTypes'
 import { ButtonV2 } from '../../Button/V2'
 import { TABLE, TableCaption } from '../table'
 import { useAllMessages } from '../useAllMessages'
@@ -81,7 +81,7 @@ type MessageHistoryTableProps = {
 
 MessageHistoryTable.propTypes = {
   offset: PropTypes.number,
-  address: ADDRESS_PROPTYPE,
+  address: ADDRESS_PROPTYPE_REQUIRED,
   cidHref: PropTypes.func.isRequired
 }
 

--- a/src/components/HistoryTables/MessageHistory/index.tsx
+++ b/src/components/HistoryTables/MessageHistory/index.tsx
@@ -4,7 +4,7 @@ import Box from '../../Box'
 import MessageConfirmedRow from './MessageConfirmedRow'
 import MessagePendingRow from './MessagePendingRow'
 import { MessageRowColumnTitles } from './MessageRowColumnTitles'
-import { ADDRESS_PROPTYPE_REQUIRED } from '../../../customPropTypes'
+import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import { ButtonV2 } from '../../Button/V2'
 import { TABLE, TableCaption } from '../table'
 import { useAllMessages } from '../useAllMessages'
@@ -81,7 +81,7 @@ type MessageHistoryTableProps = {
 
 MessageHistoryTable.propTypes = {
   offset: PropTypes.number,
-  address: ADDRESS_PROPTYPE_REQUIRED,
+  address: ADDRESS_PROPTYPE.isRequired,
   cidHref: PropTypes.func.isRequired
 }
 

--- a/src/components/HistoryTables/MsigProposals/Proposal.tsx
+++ b/src/components/HistoryTables/MsigProposals/Proposal.tsx
@@ -6,7 +6,7 @@ import Box from '../../Box'
 import { P } from '../../Typography'
 import { AddressLink } from '../../AddressLink'
 import { ProposalHead, Line, Parameters } from '../detail'
-import { ADDRESS_PROPTYPE_REQUIRED } from '../../../customPropTypes'
+import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import {
   Address,
   MsigTransaction,
@@ -223,9 +223,9 @@ export default function ProposalDetail(props: ProposalDetailProps) {
 
 ProposalDetail.propTypes = {
   id: PropTypes.number.isRequired,
-  walletAddress: ADDRESS_PROPTYPE_REQUIRED,
+  walletAddress: ADDRESS_PROPTYPE.isRequired,
   cid: PropTypes.string,
-  address: ADDRESS_PROPTYPE_REQUIRED,
+  address: ADDRESS_PROPTYPE.isRequired,
   accept: PropTypes.func,
   reject: PropTypes.func
 }

--- a/src/components/HistoryTables/MsigProposals/Proposal.tsx
+++ b/src/components/HistoryTables/MsigProposals/Proposal.tsx
@@ -6,7 +6,7 @@ import Box from '../../Box'
 import { P } from '../../Typography'
 import { AddressLink } from '../../AddressLink'
 import { ProposalHead, Line, Parameters } from '../detail'
-import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+import { ADDRESS_PROPTYPE_REQUIRED } from '../../../customPropTypes'
 import {
   Address,
   MsigTransaction,
@@ -223,9 +223,9 @@ export default function ProposalDetail(props: ProposalDetailProps) {
 
 ProposalDetail.propTypes = {
   id: PropTypes.number.isRequired,
-  walletAddress: ADDRESS_PROPTYPE,
+  walletAddress: ADDRESS_PROPTYPE_REQUIRED,
   cid: PropTypes.string,
-  address: ADDRESS_PROPTYPE,
+  address: ADDRESS_PROPTYPE_REQUIRED,
   accept: PropTypes.func,
   reject: PropTypes.func
 }

--- a/src/components/HistoryTables/MsigProposals/index.tsx
+++ b/src/components/HistoryTables/MsigProposals/index.tsx
@@ -3,7 +3,7 @@ import { isAddrEqual } from '../../../utils'
 import Box from '../../Box'
 import ProposalRow from './ProposalRow'
 import { ProposalRowColumnTitles } from './ProposalRowColumnTitles'
-import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
+import { ADDRESS_PROPTYPE_REQUIRED } from '../../../customPropTypes'
 import { TABLE, TableCaption } from '../table'
 import { useMsigPendingQuery } from '../../../generated/graphql'
 import { Title } from '../generic'
@@ -60,8 +60,8 @@ type ProposalHistoryTableProps = {
 
 ProposalHistoryTable.propTypes = {
   idHref: PropTypes.func,
-  address: ADDRESS_PROPTYPE,
-  walletAddr: ADDRESS_PROPTYPE
+  address: ADDRESS_PROPTYPE_REQUIRED,
+  walletAddr: ADDRESS_PROPTYPE_REQUIRED
 }
 
 ProposalHistoryTable.defaultProps = {

--- a/src/components/HistoryTables/MsigProposals/index.tsx
+++ b/src/components/HistoryTables/MsigProposals/index.tsx
@@ -3,7 +3,7 @@ import { isAddrEqual } from '../../../utils'
 import Box from '../../Box'
 import ProposalRow from './ProposalRow'
 import { ProposalRowColumnTitles } from './ProposalRowColumnTitles'
-import { ADDRESS_PROPTYPE_REQUIRED } from '../../../customPropTypes'
+import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import { TABLE, TableCaption } from '../table'
 import { useMsigPendingQuery } from '../../../generated/graphql'
 import { Title } from '../generic'
@@ -60,8 +60,8 @@ type ProposalHistoryTableProps = {
 
 ProposalHistoryTable.propTypes = {
   idHref: PropTypes.func,
-  address: ADDRESS_PROPTYPE_REQUIRED,
-  walletAddr: ADDRESS_PROPTYPE_REQUIRED
+  address: ADDRESS_PROPTYPE.isRequired,
+  walletAddr: ADDRESS_PROPTYPE.isRequired
 }
 
 ProposalHistoryTable.defaultProps = {

--- a/src/components/Input/Funds.tsx
+++ b/src/components/Input/Funds.tsx
@@ -5,7 +5,7 @@ import { FilecoinNumber, BigNumber } from '@glif/filecoin-number'
 import Box from '../Box'
 import { RawNumberInput, DenomTag } from './Number'
 import { Text, Label } from '../Typography'
-import { FILECOIN_NUMBER_PROPTYPE_REQUIRED } from '../../customPropTypes'
+import { FILECOIN_NUMBER_PROPTYPE } from '../../customPropTypes'
 import noop from '../../utils/noop'
 
 const formatFilValue = (number?: FilecoinNumber | string | number) => {
@@ -201,7 +201,7 @@ Funds.propTypes = {
   /**
    * Balance of account sending the transaction
    */
-  balance: FILECOIN_NUMBER_PROPTYPE_REQUIRED,
+  balance: FILECOIN_NUMBER_PROPTYPE.isRequired,
   /**
    * A string that represents the error message to display
    */
@@ -212,7 +212,7 @@ Funds.propTypes = {
   setError: func,
   disabled: bool,
   valid: bool,
-  amount: oneOfType([string, FILECOIN_NUMBER_PROPTYPE_REQUIRED]),
+  amount: oneOfType([string, FILECOIN_NUMBER_PROPTYPE.isRequired]),
   label: string,
   allowZeroValue: bool
 }

--- a/src/components/Input/Funds.tsx
+++ b/src/components/Input/Funds.tsx
@@ -5,7 +5,7 @@ import { FilecoinNumber, BigNumber } from '@glif/filecoin-number'
 import Box from '../Box'
 import { RawNumberInput, DenomTag } from './Number'
 import { Text, Label } from '../Typography'
-import { FILECOIN_NUMBER_PROP } from '../../customPropTypes'
+import { FILECOIN_NUMBER_PROPTYPE_REQUIRED } from '../../customPropTypes'
 import noop from '../../utils/noop'
 
 const formatFilValue = (number?: FilecoinNumber | string | number) => {
@@ -201,7 +201,7 @@ Funds.propTypes = {
   /**
    * Balance of account sending the transaction
    */
-  balance: FILECOIN_NUMBER_PROP,
+  balance: FILECOIN_NUMBER_PROPTYPE_REQUIRED,
   /**
    * A string that represents the error message to display
    */
@@ -212,7 +212,7 @@ Funds.propTypes = {
   setError: func,
   disabled: bool,
   valid: bool,
-  amount: oneOfType([string, FILECOIN_NUMBER_PROP]),
+  amount: oneOfType([string, FILECOIN_NUMBER_PROPTYPE_REQUIRED]),
   label: string,
   allowZeroValue: bool
 }

--- a/src/components/InputV2/Filecoin.tsx
+++ b/src/components/InputV2/Filecoin.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { FilecoinNumber } from '@glif/filecoin-number'
 import { BaseInput, BaseInputProps, BaseInputPropTypes } from './Base'
-import { FILECOIN_NUMBER_PROP } from '../../customPropTypes'
+import { FILECOIN_NUMBER_PROPTYPE } from '../../customPropTypes'
 
 type FilecoinDenomination = 'fil' | 'picofil' | 'attofil'
 
@@ -120,7 +120,7 @@ export const FilecoinInput = ({
  * error: set by filecoin input validation
  * type: always "number" for filecoin input
  * unit: will be based on the FilecoinDenomination
- * value: needs to be of type "FilecoinNumber" / "FILECOIN_NUMBER_PROP"
+ * value: needs to be of type "FilecoinNumber" / "FILECOIN_NUMBER_PROPTYPE"
  * onChange: needs to take "FilecoinNumber" type argument
  * onBlur: needs to take "FilecoinNumber" type argument
  */
@@ -142,9 +142,9 @@ export type FilecoinInputProps = {
 const { error, type, unit, value, ...filecoinProps } = BaseInputPropTypes
 
 FilecoinInput.propTypes = {
-  min: FILECOIN_NUMBER_PROP,
-  max: FILECOIN_NUMBER_PROP,
-  value: FILECOIN_NUMBER_PROP,
+  min: FILECOIN_NUMBER_PROPTYPE,
+  max: FILECOIN_NUMBER_PROPTYPE,
+  value: FILECOIN_NUMBER_PROPTYPE,
   denom: PropTypes.oneOf(['fil', 'picofil', 'attofil']),
   setHasError: PropTypes.func,
   ...filecoinProps

--- a/src/customPropTypes.js
+++ b/src/customPropTypes.js
@@ -23,21 +23,30 @@ export const GRAPHQL_ADDRESS_PROP_TYPE = shape({
   robust: string
 })
 
-export const FILECOIN_NUMBER_PROP = (props, propName, componentName) => {
-  // instanceof prop checking is broken in nextjs on server side render cycles
-  const representsANum = Number.isNaN(Number(props[propName].toString()))
-  const hasFilecoinNumMethods = !!(
-    props[propName].toFil &&
-    props[propName].toAttoFil &&
-    props[propName].toPicoFil
-  )
-  if (!(representsANum || hasFilecoinNumMethods))
-    return new Error(
-      `Invalid prop: ${propName} supplied to ${componentName}. Validation failed.`
-    )
+const createFilecoinNumberPropType =
+  isRequired => (props, propName, componentName) => {
+    const prop = props[propName]
+    if (prop == null) {
+      if (isRequired) {
+        return new Error(`Missing prop "${propName}" in "${componentName}"`)
+      }
+    } else {
+      // instanceof prop checking is broken in nextjs on server side render cycles
+      const isFilecoinNumber =
+        typeof prop === 'object' &&
+        'toFil' in prop &&
+        'toAttoFil' in prop &&
+        'toPicoFil' in prop
+      if (!isFilecoinNumber)
+        return new Error(
+          `Invalid prop "${propName}" supplied to "${componentName}"`
+        )
+    }
+  }
 
-  return null
-}
+export const FILECOIN_NUMBER_PROPTYPE = createFilecoinNumberPropType(false)
+export const FILECOIN_NUMBER_PROPTYPE_REQUIRED =
+  createFilecoinNumberPropType(true)
 
 export const MESSAGE_PROPS = shape({
   /**

--- a/src/customPropTypes.js
+++ b/src/customPropTypes.js
@@ -1,14 +1,21 @@
 import { shape, string, oneOfType, number, oneOf, object } from 'prop-types'
 import { validateAddressString } from '@glif/filecoin-address'
 
-export const ADDRESS_PROPTYPE = (props, propName, componentName) => {
-  if (!validateAddressString(props[propName]))
+const createAddressPropType = isRequired => (props, propName, componentName) => {
+  const prop = props[propName]
+  if (prop == null) {
+    if (isRequired) {
+      return new Error(`Missing prop "${propName}" in "${componentName}"`);
+    }
+  } else if (!validateAddressString(prop)) {
     return new Error(
-      `Invalid prop: ${propName} supplied to ${componentName}. Validation failed.`
+      `Invalid prop "${propName}" supplied to "${componentName}"`
     )
-
-  return null
+  }
 }
+
+export const ADDRESS_PROPTYPE = createAddressPropType(false)
+export const ADDRESS_PROPTYPE_REQUIRED = createAddressPropType(true)
 
 export const GRAPHQL_ADDRESS_PROP_TYPE = shape({
   id: string,
@@ -35,11 +42,11 @@ export const MESSAGE_PROPS = shape({
   /**
    * Message sent to this address
    */
-  to: ADDRESS_PROPTYPE,
+  to: ADDRESS_PROPTYPE_REQUIRED,
   /**
    * Message sent from this address
    */
-  from: ADDRESS_PROPTYPE,
+  from: ADDRESS_PROPTYPE_REQUIRED,
   /**
    * The amount of FIL sent in the message
    */

--- a/src/customPropTypes.js
+++ b/src/customPropTypes.js
@@ -1,18 +1,19 @@
 import { shape, string, oneOfType, number, oneOf, object } from 'prop-types'
 import { validateAddressString } from '@glif/filecoin-address'
 
-const createAddressPropType = isRequired => (props, propName, componentName) => {
-  const prop = props[propName]
-  if (prop == null) {
-    if (isRequired) {
-      return new Error(`Missing prop "${propName}" in "${componentName}"`);
+const createAddressPropType =
+  isRequired => (props, propName, componentName) => {
+    const prop = props[propName]
+    if (prop == null) {
+      if (isRequired) {
+        return new Error(`Missing prop "${propName}" in "${componentName}"`)
+      }
+    } else if (!validateAddressString(prop)) {
+      return new Error(
+        `Invalid prop "${propName}" supplied to "${componentName}"`
+      )
     }
-  } else if (!validateAddressString(prop)) {
-    return new Error(
-      `Invalid prop "${propName}" supplied to "${componentName}"`
-    )
   }
-}
 
 export const ADDRESS_PROPTYPE = createAddressPropType(false)
 export const ADDRESS_PROPTYPE_REQUIRED = createAddressPropType(true)

--- a/src/customPropTypes.ts
+++ b/src/customPropTypes.ts
@@ -1,5 +1,10 @@
-import { shape, string, oneOfType, number, oneOf, object } from 'prop-types'
+import { shape, string, oneOfType, number, oneOf, object, Requireable } from 'prop-types'
 import { validateAddressString } from '@glif/filecoin-address'
+
+interface CustomPropType {
+  (a: number, b: string): string[];
+  foo: string;
+}
 
 const createAddressPropType =
   isRequired => (props, propName, componentName) => {
@@ -15,8 +20,10 @@ const createAddressPropType =
     }
   }
 
-export const ADDRESS_PROPTYPE = createAddressPropType(false)
-export const ADDRESS_PROPTYPE_REQUIRED = createAddressPropType(true)
+export const ADDRESS_PROPTYPE: Requireable<any> = Object.assign(
+  createAddressPropType(false),
+  { isRequired: createAddressPropType(true) }
+)
 
 export const GRAPHQL_ADDRESS_PROP_TYPE = shape({
   id: string,
@@ -52,11 +59,11 @@ export const MESSAGE_PROPS = shape({
   /**
    * Message sent to this address
    */
-  to: ADDRESS_PROPTYPE_REQUIRED,
+  to: ADDRESS_PROPTYPE.isRequired,
   /**
    * Message sent from this address
    */
-  from: ADDRESS_PROPTYPE_REQUIRED,
+  from: ADDRESS_PROPTYPE.isRequired,
   /**
    * The amount of FIL sent in the message
    */

--- a/src/customPropTypes.ts
+++ b/src/customPropTypes.ts
@@ -51,9 +51,10 @@ const createFilecoinNumberPropType =
     }
   }
 
-export const FILECOIN_NUMBER_PROPTYPE = createFilecoinNumberPropType(false)
-export const FILECOIN_NUMBER_PROPTYPE_REQUIRED =
-  createFilecoinNumberPropType(true)
+export const FILECOIN_NUMBER_PROPTYPE: Requireable<any> = Object.assign(
+  createFilecoinNumberPropType(false),
+  { isRequired: createFilecoinNumberPropType(true) }
+)
 
 export const MESSAGE_PROPS = shape({
   /**

--- a/src/customPropTypes.ts
+++ b/src/customPropTypes.ts
@@ -1,10 +1,13 @@
-import { shape, string, oneOfType, number, oneOf, object, Requireable } from 'prop-types'
+import {
+  shape,
+  string,
+  oneOfType,
+  number,
+  oneOf,
+  object,
+  Requireable
+} from 'prop-types'
 import { validateAddressString } from '@glif/filecoin-address'
-
-interface CustomPropType {
-  (a: number, b: string): string[];
-  foo: string;
-}
 
 const createAddressPropType =
   isRequired => (props, propName, componentName) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components'
+export * from './customPropTypes'
 export * from './utils'
 export * from './generated/graphql'


### PR DESCRIPTION
I've tried the approach of creating proptypes that can be used as such:
```
FILECOIN_NUMBER_PROPTYPE
FILECOIN_NUMBER_PROPTYPE.isRequired
```
But didn't get it to work without TypeScript complaining about the `isRequired` variants.
So ended up with this:
```
FILECOIN_NUMBER_PROPTYPE
FILECOIN_NUMBER_PROPTYPE_REQUIRED
``` 
Another thing I noticed is that each app redefines these proptypes, I imagine they could be shared from `react-components`, so I've added them to the export of `src\index.ts`