### PR TITLE
Logger updates

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,8 +3,10 @@ import { Logger, LogLevel } from '@glif/logger'
 const IS_PROD: boolean = !!process.env.NEXT_PUBLIC_IS_PROD
 const SENTRY_DSN: string = process.env.NEXT_PUBLIC_SENTRY_DSN || ''
 const SENTRY_ENV: string = process.env.NEXT_PUBLIC_SENTRY_ENV || ''
-const PACKAGE_NAME: string = process.env.NEXT_PUBLIC_PACKAGE_NAME || 'wallet-provider-react'
-const PACKAGE_VERSION: string = process.env.NEXT_PUBLIC_PACKAGE_VERSION || '?.?.?'
+const PACKAGE_NAME: string =
+  process.env.NEXT_PUBLIC_PACKAGE_NAME || 'react-components'
+const PACKAGE_VERSION: string =
+  process.env.NEXT_PUBLIC_PACKAGE_VERSION || '?.?.?'
 
 export const logger = new Logger({
   consoleEnabled: true,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,14 +1,19 @@
-import { Logger } from '@glif/logger'
+import { Logger, LogLevel } from '@glif/logger'
 
-const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN! as string
-const SENTRY_ENV = process.env.NEXT_PUBLIC_SENTRY_ENV! as string
-const ENABLE_SENTRY = process.env.NEXT_PUBLIC_ENABLE_SENTRY! as string
+const IS_PROD: boolean = !!process.env.NEXT_PUBLIC_IS_PROD
+const SENTRY_DSN: string = process.env.NEXT_PUBLIC_SENTRY_DSN || ''
+const SENTRY_ENV: string = process.env.NEXT_PUBLIC_SENTRY_ENV || ''
+const PACKAGE_NAME: string = process.env.NEXT_PUBLIC_PACKAGE_NAME || 'wallet-provider-react'
+const PACKAGE_VERSION: string = process.env.NEXT_PUBLIC_PACKAGE_VERSION || '?.?.?'
 
 export const logger = new Logger({
-  sentryTraces: 0,
+  consoleEnabled: true,
+  consoleLevel: LogLevel.DEBUG,
+  sentryEnabled: IS_PROD,
+  sentryLevel: LogLevel.WARN,
   sentryDsn: SENTRY_DSN,
   sentryEnv: SENTRY_ENV,
-  sentryEnabled: !!ENABLE_SENTRY,
-  packageName: '',
-  packageVersion: ''
+  sentryTraces: 0,
+  packageName: PACKAGE_NAME,
+  packageVersion: PACKAGE_VERSION
 })


### PR DESCRIPTION
Fixes the Typescript issue and loads package name / version from environment variables. Defaults to `react-components@?.?.?` when the environment variables are not set.

Also removes the `NEXT_PUBLIC_ENABLE_SENTRY` variable because it is never set in any of the apps, so probably Sentry isn't working in any of them in production.

Also explicitly sets log levels and enables console output.