### PR TITLE
Allow useWalletProvider to access a stubbed ctx

### DIFF
--- a/src/components/Transaction/Form.tsx
+++ b/src/components/Transaction/Form.tsx
@@ -19,7 +19,11 @@ import { TransactionTotal } from './Total'
 import { Dialog, ShadowBox } from '../Layout'
 import { useSubmittedMessages } from '../HistoryTables/PendingMsgContext'
 import { getMaxGasFee } from '../../utils'
-import { useWallet, useWalletProvider } from '../../services'
+import {
+  useWallet,
+  useWalletProvider,
+  WalletProviderOpts
+} from '../../services'
 import { logger } from '../../logger'
 
 export const TransactionForm = ({
@@ -36,13 +40,14 @@ export const TransactionForm = ({
   maxFee,
   txFee,
   setTxFee,
-  onComplete
+  onComplete,
+  walletProviderOpts
 }: TransactionFormProps) => {
   const router = useRouter()
   const wallet = useWallet()
   const { pushPendingMessage } = useSubmittedMessages()
   const { loginOption, walletError, walletProvider, getProvider } =
-    useWalletProvider()
+    useWalletProvider(walletProviderOpts)
 
   // Transaction states
   const [txError, setTxError] = useState<Error | null>(null)
@@ -188,6 +193,8 @@ export type TransactionFormProps = {
   txFee: FilecoinNumber
   setTxFee: (fee: FilecoinNumber) => void
   onComplete: () => void
+  // used for testing with a stubbed context value
+  walletProviderOpts: WalletProviderOpts
 }
 
 TransactionForm.propTypes = {
@@ -207,5 +214,6 @@ TransactionForm.propTypes = {
   maxFee: FILECOIN_NUMBER_PROPTYPE.isRequired,
   txFee: FILECOIN_NUMBER_PROPTYPE.isRequired,
   setTxFee: PropTypes.func.isRequired,
-  onComplete: PropTypes.func.isRequired
+  onComplete: PropTypes.func.isRequired,
+  walletProviderOpts: PropTypes.object
 }

--- a/src/services/WalletProvider/index.tsx
+++ b/src/services/WalletProvider/index.tsx
@@ -4,7 +4,8 @@ import {
   useReducer,
   useCallback,
   Dispatch,
-  ReactChildren
+  ReactChildren,
+  Context
 } from 'react'
 import PropTypes from 'prop-types'
 import Filecoin, {
@@ -212,8 +213,19 @@ WalletProviderWrapper.propTypes = {
   children: PropTypes.node.isRequired
 }
 
-export const useWalletProvider = () => {
-  const value = useContext(WalletProviderContext)
+export type WalletProviderOpts = {
+  context: Context<WalletProviderContextType>
+}
+
+export const useWalletProvider = (opts?: WalletProviderOpts) => {
+  let ctx: Context<WalletProviderContextType>
+  if (opts?.context) {
+    ctx = opts.context
+  } else {
+    ctx = WalletProviderContext
+  }
+
+  const value = useContext(ctx)
   const { state } = value
   return {
     ...state,

--- a/src/services/WalletProvider/useWallet/index.ts
+++ b/src/services/WalletProvider/useWallet/index.ts
@@ -1,5 +1,5 @@
 import { FilecoinNumber } from '@glif/filecoin-number'
-import { useWalletProvider } from '../'
+import { useWalletProvider, WalletProviderOpts } from '../'
 import { Wallet } from '../types'
 
 const noWallet: Wallet = {
@@ -8,8 +8,8 @@ const noWallet: Wallet = {
   path: ''
 }
 
-export default function useWallet(): Wallet {
-  const { wallets, selectedWalletIdx } = useWalletProvider()
+export default function useWallet(opts?: WalletProviderOpts): Wallet {
+  const { wallets, selectedWalletIdx } = useWalletProvider(opts)
 
   if (wallets.length === 0) return noWallet
   if (!wallets[selectedWalletIdx]) return noWallet


### PR DESCRIPTION
Hey @navFooh I'm going to merge and publish this so I can fix the tests in the wallet, but I got a better understanding of what was going wrong with the mocking.

Notice how `useWalletProvider` always uses the context defined in its own file - this works fine for non-test use cases, since the wallet and safe always default to using the context defined in that same file. However, in test environments, we want to use a different context (one thats defined in our mocks, and not defined in this wallet provider service).

I think the cleanest way to move forward here is to allow `useWalletProvider` to take an optional context.