### PR TITLE
Export parameters

### DIFF
--- a/src/components/HistoryTables/ActorState/index.tsx
+++ b/src/components/HistoryTables/ActorState/index.tsx
@@ -10,7 +10,7 @@ import {
 import Box from '../../Box'
 import { P } from '../../Typography'
 import { Title } from '../generic'
-import { DetailCaption, Line } from '../detail'
+import { DetailCaption, LineWrapper, Line } from '../detail'
 import convertAddrToPrefix from '../../../utils/convertAddrToPrefix'
 
 const ViewState = styled(P).attrs(() => ({
@@ -60,7 +60,7 @@ export function ActorState({ address }: { address: string }) {
   }, [actorStateError, adddressError])
 
   return (
-    <Box>
+    <div>
       <Title>Overview</Title>
       <hr />
       <DetailCaption
@@ -70,7 +70,7 @@ export function ActorState({ address }: { address: string }) {
         error={error}
       />
       {!loading && !error && (
-        <>
+        <LineWrapper>
           {addressData?.address.robust && (
             <Line label='Robust address'>{addressData?.address.robust}</Line>
           )}
@@ -93,7 +93,6 @@ export function ActorState({ address }: { address: string }) {
           <Box
             display='flex'
             gridGap='1em'
-            my='1em'
             lineHeight='2em'
             alignItems='center'
           >
@@ -106,8 +105,8 @@ export function ActorState({ address }: { address: string }) {
             </ViewState>
           </Box>
           <Box>{viewActorState && <State state={actorStateData?.State} />}</Box>
-        </>
+        </LineWrapper>
       )}
-    </Box>
+    </div>
   )
 }

--- a/src/components/HistoryTables/MessageHistory/Detail.tsx
+++ b/src/components/HistoryTables/MessageHistory/Detail.tsx
@@ -7,7 +7,6 @@ import {
   useChainHeadSubscription,
   MessageConfirmed
 } from '../../../generated/graphql'
-import Box from '../../Box'
 import { IconClock } from '../../Icons'
 import { AddressLink } from '../../AddressLink'
 import { P } from '../../Typography'
@@ -15,6 +14,7 @@ import { Badge } from '../generic'
 import {
   Head,
   DetailCaption,
+  LineWrapper,
   Line,
   Status,
   Confirmations,
@@ -86,7 +86,7 @@ export default function MessageDetail(props: MessageDetailProps) {
   )
 
   return (
-    <Box>
+    <>
       <Head
         title='Message Overview'
         pending={pending}
@@ -102,7 +102,7 @@ export default function MessageDetail(props: MessageDetailProps) {
           </P>
         </Card>
       ) : (
-        <>
+        <LineWrapper>
           <DetailCaption
             name='Message Overview'
             captian='Scanning Filecoin for your message... This could take a minute.'
@@ -228,9 +228,9 @@ export default function MessageDetail(props: MessageDetailProps) {
               </P>
             </Card>
           )}
-        </>
+        </LineWrapper>
       )}
-    </Box>
+    </>
   )
 }
 

--- a/src/components/HistoryTables/MsigProposals/Proposal.tsx
+++ b/src/components/HistoryTables/MsigProposals/Proposal.tsx
@@ -201,7 +201,9 @@ export default function ProposalDetail(props: ProposalDetailProps) {
         <hr />
         {seeMore && (
           <>
-            <Line label='Next Transaction ID'>{stateData?.State.NextTxnID}</Line>
+            <Line label='Next Transaction ID'>
+              {stateData?.State.NextTxnID}
+            </Line>
             <Line
               label={`Approvers${
                 proposal?.approved ? ` (${proposal?.approved.length})` : ''

--- a/src/components/HistoryTables/MsigProposals/Proposal.tsx
+++ b/src/components/HistoryTables/MsigProposals/Proposal.tsx
@@ -2,10 +2,9 @@ import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { useRouter } from 'next/router'
-import Box from '../../Box'
 import { P } from '../../Typography'
 import { AddressLink } from '../../AddressLink'
-import { ProposalHead, Line, Parameters } from '../detail'
+import { ProposalHead, LineWrapper, Line, Parameters } from '../detail'
 import { ADDRESS_PROPTYPE } from '../../../customPropTypes'
 import {
   Address,
@@ -157,7 +156,7 @@ export default function ProposalDetail(props: ProposalDetailProps) {
     )
 
   return (
-    <Box>
+    <div>
       <ProposalHead
         title='Proposal Overview'
         accept={props.accept}
@@ -168,56 +167,58 @@ export default function ProposalDetail(props: ProposalDetailProps) {
         isProposer={isProposer}
       />
       <hr />
-      <Line label='Proposal ID'>{props.id}</Line>
-      <Line label='Proposer'>
-        {proposal?.approved[0] && (
-          <AddressLink
-            id={proposal.approved[0].id}
-            address={proposal.approved[0].robust}
-            hideCopyText={false}
-          />
+      <LineWrapper>
+        <Line label='Proposal ID'>{props.id}</Line>
+        <Line label='Proposer'>
+          {proposal?.approved[0] && (
+            <AddressLink
+              id={proposal.approved[0].id}
+              address={proposal.approved[0].robust}
+              hideCopyText={false}
+            />
+          )}
+        </Line>
+        <Line label='Approvals until execution'>
+          {approvalsUntilExecution.toString()}
+        </Line>
+        <hr />
+        <Parameters
+          params={{
+            params: {
+              to: proposal.to.robust,
+              value: proposal.value,
+              method: proposal.method,
+              params: proposal.params
+            }
+          }}
+          actorName='/multisig'
+          depth={0}
+        />
+        <hr />
+        <SeeMore onClick={() => setSeeMore(!seeMore)}>
+          Click to see {seeMore ? 'less ↑' : 'more ↓'}
+        </SeeMore>
+        <hr />
+        {seeMore && (
+          <>
+            <Line label='Next Transaction ID'>{stateData?.State.NextTxnID}</Line>
+            <Line
+              label={`Approvers${
+                proposal?.approved ? ` (${proposal?.approved.length})` : ''
+              }`}
+            >
+              {proposal?.approved.map((approver: Address) => (
+                <AddressLink
+                  key={approver.robust || approver.id}
+                  id={approver.id}
+                  address={approver.robust}
+                />
+              ))}
+            </Line>
+          </>
         )}
-      </Line>
-      <Line label='Approvals until execution'>
-        {approvalsUntilExecution.toString()}
-      </Line>
-      <hr />
-      <Parameters
-        params={{
-          params: {
-            to: proposal.to.robust,
-            value: proposal.value,
-            method: proposal.method,
-            params: proposal.params
-          }
-        }}
-        actorName='/multisig'
-        depth={0}
-      />
-      <hr />
-      <SeeMore onClick={() => setSeeMore(!seeMore)}>
-        Click to see {seeMore ? 'less ↑' : 'more ↓'}
-      </SeeMore>
-      <hr />
-      {seeMore && (
-        <>
-          <Line label='Next Transaction ID'>{stateData?.State.NextTxnID}</Line>
-          <Line
-            label={`Approvers${
-              proposal?.approved ? ` (${proposal?.approved.length})` : ''
-            }`}
-          >
-            {proposal?.approved.map((approver: Address) => (
-              <AddressLink
-                key={approver.robust || approver.id}
-                id={approver.id}
-                address={approver.robust}
-              />
-            ))}
-          </Line>
-        </>
-      )}
-    </Box>
+      </LineWrapper>
+    </div>
   )
 }
 

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -190,6 +190,7 @@ export const Line = ({ label, depth, children }: LineProps) => (
     alignItems='center'
     gridGap='1em'
     lineHeight='2em'
+    textAlign='left'
     my='1em'
     pl={`${depth * 5}%`}
     css={`

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -256,7 +256,9 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
           )
         }
 
-        case 'to': {
+        case 'to':
+        case 'from':
+        case 'signer': {
           switch (typeof value) {
             case 'string':
               return (

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -192,7 +192,7 @@ export const Line = ({ label, depth, children }: LineProps) => (
     lineHeight='2em'
     textAlign='left'
     my='1em'
-    pl={`${depth * 5}%`}
+    pl={`${depth * 1.5}em`}
     css={`
       a {
         color: ${props => props.theme.colors.core.primary};

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -326,7 +326,7 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
             case 'object':
               if (value)
                 return (
-                  <div key={`${depth}-${key}`}>
+                  <LineWrapper key={`${depth}-${key}`}>
                     <Line
                       label={key === 'params' ? 'Parameters' : key}
                       depth={depth}
@@ -336,7 +336,7 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
                       depth={depth + 1}
                       actorName={actorName}
                     />
-                  </div>
+                  </LineWrapper>
                 )
 
             case 'boolean':

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -180,6 +180,16 @@ DetailCaption.propTypes = {
   error: PropTypes.object
 }
 
+export const LineWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  
+  p, hr {
+    margin: 0;
+  }
+`
+
 /**
  * Line
  * Content row of the detail page
@@ -191,7 +201,6 @@ export const Line = ({ label, depth, children }: LineProps) => (
     gridGap='1em'
     lineHeight='2em'
     textAlign='left'
-    my='1em'
     pl={`${depth * 1.5}em`}
     css={`
       a {

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -14,6 +14,7 @@ import {
   IconPending,
   IconFail
 } from '../Icons'
+import { ADDRESS_PROPTYPE } from '../../customPropTypes'
 import { PROPOSAL_ROW_PROP_TYPE } from './types'
 import { getMethodName } from './methodName'
 
@@ -225,16 +226,41 @@ type LineProps = {
   children?: React.ReactNode
 }
 
-Line.propTypes = {
+const LinePropTypes = {
   label: PropTypes.string,
   depth: PropTypes.number,
   children: PropTypes.node
 }
 
+Line.propTypes = LinePropTypes
 Line.defaultProps = {
   label: '',
   depth: 0,
   children: <></>
+}
+
+/**
+ * AddressLine
+ */
+
+export const AddressLine = ({ value, label, depth }: AddressLineProps) =>
+  typeof value === 'string' ? (
+    <Line label={label} depth={depth}>
+      <AddressLink address={value} hideCopyText={false} />
+    </Line>
+  ) : (
+    <Line label={label} depth={depth}>
+      <AddressLink id={value.id} address={value.robust} hideCopyText={false} />
+    </Line>
+  )
+
+type AddressLineProps = {
+  value: string | Address
+} & LineProps
+
+AddressLine.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, ADDRESS_PROPTYPE]).isRequired,
+  ...LinePropTypes
 }
 
 /**
@@ -258,30 +284,15 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
 
         case 'to':
         case 'from':
-        case 'signer': {
-          switch (typeof value) {
-            case 'string':
-              return (
-                <Line key={`${depth}-${key}`} label={key} depth={depth}>
-                  <AddressLink address={value} hideCopyText={false} />
-                </Line>
-              )
-
-            case 'object':
-              if (value) {
-                const address = value as Address
-                return (
-                  <Line key={`${depth}-${key}`} label={key} depth={depth}>
-                    <AddressLink
-                      id={address.id}
-                      address={address.robust}
-                      hideCopyText={false}
-                    />
-                  </Line>
-                )
-              }
-          }
-        }
+        case 'signer':
+          return (
+            <AddressLine
+              key={`${depth}-${key}`}
+              value={value}
+              label={key}
+              depth={depth}
+            />
+          )
 
         case 'value':
           return (

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -294,6 +294,16 @@ export const Parameters = ({ params, depth, actorName }: ParametersProps) => (
             />
           )
 
+        case 'approved':
+          return value.map((signer, index) => (
+            <AddressLine
+              key={`${depth}-${key}`}
+              value={signer}
+              label={index ? '' : 'Approved by'}
+              depth={depth + 1}
+            />
+          ))
+
         case 'value':
           return (
             <Line key={`${depth}-${key}`} label={key} depth={depth}>

--- a/src/components/HistoryTables/detail.tsx
+++ b/src/components/HistoryTables/detail.tsx
@@ -184,8 +184,9 @@ export const LineWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1em;
-  
-  p, hr {
+
+  p,
+  hr {
     margin: 0;
   }
 `

--- a/src/components/Transaction/Form.tsx
+++ b/src/components/Transaction/Form.tsx
@@ -167,7 +167,9 @@ export const TransactionForm = ({
       )}
       <TransactionButtons
         backDisabled={
-          txState !== TxState.FillingForm && txState !== TxState.FillingTxFee
+          txState !== TxState.LoadingFailed &&
+          txState !== TxState.FillingForm &&
+          txState !== TxState.FillingTxFee
         }
         nextDisabled={
           (txState !== TxState.FillingForm || !message) &&

--- a/src/components/Transaction/Form.tsx
+++ b/src/components/Transaction/Form.tsx
@@ -147,22 +147,24 @@ export const TransactionForm = ({
         method={method}
         approvalsLeft={approvalsLeft}
       />
-      <ShadowBox>
-        <form>
-          {children}
-          <TransactionFee
-            inputFee={inputFee}
-            setInputFee={setInputFee}
-            maxFee={maxFee}
-            txFee={txFee}
-            txState={txState}
-            onUpdate={getGasParams}
-          />
-        </form>
-        {txState > TxState.FillingForm && total && (
-          <TransactionTotal total={total} />
-        )}
-      </ShadowBox>
+      {txState >= TxState.FillingForm && (
+        <ShadowBox>
+          <form>
+            {children}
+            <TransactionFee
+              inputFee={inputFee}
+              setInputFee={setInputFee}
+              maxFee={maxFee}
+              txFee={txFee}
+              txState={txState}
+              onUpdate={getGasParams}
+            />
+          </form>
+          {txState >= TxState.FillingTxFee && total && (
+            <TransactionTotal total={total} />
+          )}
+        </ShadowBox>
+      )}
       <TransactionButtons
         backDisabled={
           txState !== TxState.FillingForm && txState !== TxState.FillingTxFee

--- a/src/components/Transaction/Header.tsx
+++ b/src/components/Transaction/Header.tsx
@@ -29,6 +29,8 @@ export const TransactionHeader = ({
           ? 'Something went wrong'
           : txState === TxState.LoadingMessage
           ? 'Loading message information...'
+          : txState === TxState.LoadingFailed
+          ? 'Failed to load message information'
           : txState === TxState.FillingTxFee
           ? 'Please review the transaction below'
           : txState === TxState.LoadingTxFee
@@ -49,6 +51,11 @@ export const TransactionHeader = ({
       (txState === TxState.FillingTxFee ||
         txState === TxState.LoadingTxFee) && <WarningBox>{warning}</WarningBox>}
     {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
+    {txState === TxState.LoadingFailed && (
+      <ErrorBox>
+        The message you are trying to access could not be loaded
+      </ErrorBox>
+    )}
     {txState === TxState.AwaitingConfirmation && (
       <TransactionConfirm
         loginOption={loginOption}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -39,6 +39,7 @@ export { default as ProposalDetail } from './HistoryTables/MsigProposals/Proposa
 export * from './HistoryTables/ActorState'
 export * from './HistoryTables/PendingMsgContext'
 export * from './HistoryTables/methodName'
+export { Parameters } from './HistoryTables/detail'
 export { defaultMessageHistoryClientCacheConfig } from './HistoryTables/defaultCacheConfig'
 export * from './NetworkConnection'
 export { default as NetworkSwitcherGlyph } from './NetworkSwitcherGlyph'

--- a/src/customPropTypes.ts
+++ b/src/customPropTypes.ts
@@ -174,6 +174,7 @@ export const MSIG_METHOD_PROPTYPE = oneOf(
 
 export enum TxState {
   LoadingMessage = 0,
+  LoadingFailed,
   FillingForm,
   FillingTxFee,
   LoadingTxFee,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { default as convertAddrToPrefix } from './convertAddrToPrefix'
 export { default as isMobileOrTablet } from './isMobileOrTablet'
 export { default as useDesktopBrowser } from './useDesktopBrowser'
 export { default as useChromeDesktopBrowser } from './useChromeDesktopBrowser'


### PR DESCRIPTION
- Removed the fixed padding for Message Detail lines, added a LineWrapper responsible for the Line layout. This was casuing too much space when using the Parameter Lines in Approve / Cancel transaction due to the flex gap used in transaction forms.
- Added proper rendering of `approvers` key in the parameters object
- Hide transaction form content while message is still loading (for approve / cancel proposal, but also necessary for tx replacement)
- Added a `LoadingFailed` transaction state (for approve / cancel proposal, but also necessary for tx replacement)
- Export Parameters component