### PR TITLE
Smartlink fixes

### DIFF
--- a/src/components/Link/SmartLink.stories.jsx
+++ b/src/components/Link/SmartLink.stories.jsx
@@ -28,3 +28,41 @@ Base.args = {
   href: 'https://google.com',
   name: 'Click here'
 }
+
+export const Internal1 = Template.bind({})
+Internal1.args = {
+  href: '/home',
+  name: 'Home'
+}
+
+export const Internal2 = Template.bind({})
+Internal2.args = {
+  href: 'admin',
+  name: 'Admin'
+}
+
+export const DownloadInternal = Template.bind({})
+DownloadInternal.args = {
+  href: '/favicon.ico',
+  download: true,
+  name: 'Download'
+}
+
+export const DownloadExternal = Template.bind({})
+DownloadExternal.args = {
+  href: 'http://localhost:6006/favicon.ico',
+  download: true,
+  name: 'Download'
+}
+
+export const MailTo = Template.bind({})
+MailTo.args = {
+  href: 'mailto:squad@glif.io',
+  name: 'squad@glif.io'
+}
+
+export const Tel = Template.bind({})
+Tel.args = {
+  href: 'tel:+4733378901',
+  name: '+4733378901'
+}

--- a/src/components/Link/SmartLink.test.tsx
+++ b/src/components/Link/SmartLink.test.tsx
@@ -1,0 +1,165 @@
+import {
+  render,
+  act,
+  getByRole,
+  RenderResult
+} from '@testing-library/react'
+import { SmartLink } from './SmartLink'
+  
+const linkText = 'Click me'
+const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+useRouter.mockImplementation(() => ({
+  query: { foo: 'bar', glif: 'ftw' }
+}))
+
+describe('SmartLink', () => {
+  test('it renders internal links correctly', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='/home'>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', '/home')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it renders external links correctly', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='https://google.com'>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', 'https://google.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it renders internal download links correctly', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='/favicon.ico' download>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', '/favicon.ico')
+    expect(link).toHaveAttribute('target', '_self')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it renders external download links correctly', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='http://localhost:6006/favicon.ico' download>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', 'http://localhost:6006/favicon.ico')
+    expect(link).toHaveAttribute('target', '_self')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it renders mailto links correctly', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='mailto:squad@glif.io'>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', 'mailto:squad@glif.io')
+    expect(link).toHaveAttribute('target', '_self')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it renders tel links correctly', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='tel:+4733378901'>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', 'tel:+4733378901')
+    expect(link).toHaveAttribute('target', '_self')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it can retain params for internal links', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='/home' retainParams>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', '/home?foo=bar&glif=ftw')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it doesn\'t retain params for external links', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='https://google.com' retainParams>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', 'https://google.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it can add params to internal links', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='/home' params={{
+          test1: ['a', 'b'],
+          test2: [1, 2],
+          test3: 'abc',
+          test4: 123
+        }}>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', '/home?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+
+  test('it can add params to external links', async () => {
+    let result: RenderResult | null = null
+    await act(async () => {
+      result = render(
+        <SmartLink href='https://google.com' params={{
+          test1: ['a', 'b'],
+          test2: [1, 2],
+          test3: 'abc',
+          test4: 123
+        }}>{linkText}</SmartLink>
+      )
+    })
+    const link = getByRole(result!.container, 'link')
+    expect(link).toHaveAttribute('href', 'https://google.com?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+    expect(result!.container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/Link/SmartLink.test.tsx
+++ b/src/components/Link/SmartLink.test.tsx
@@ -1,11 +1,6 @@
-import {
-  render,
-  act,
-  getByRole,
-  RenderResult
-} from '@testing-library/react'
+import { render, act, getByRole, RenderResult } from '@testing-library/react'
 import { SmartLink } from './SmartLink'
-  
+
 const linkText = 'Click me'
 const useRouter = jest.spyOn(require('next/router'), 'useRouter')
 useRouter.mockImplementation(() => ({
@@ -16,9 +11,7 @@ describe('SmartLink', () => {
   test('it renders internal links correctly', async () => {
     let result: RenderResult | null = null
     await act(async () => {
-      result = render(
-        <SmartLink href='/home'>{linkText}</SmartLink>
-      )
+      result = render(<SmartLink href='/home'>{linkText}</SmartLink>)
     })
     const link = getByRole(result!.container, 'link')
     expect(link).toHaveAttribute('href', '/home')
@@ -45,7 +38,9 @@ describe('SmartLink', () => {
     let result: RenderResult | null = null
     await act(async () => {
       result = render(
-        <SmartLink href='/favicon.ico' download>{linkText}</SmartLink>
+        <SmartLink href='/favicon.ico' download>
+          {linkText}
+        </SmartLink>
       )
     })
     const link = getByRole(result!.container, 'link')
@@ -59,7 +54,9 @@ describe('SmartLink', () => {
     let result: RenderResult | null = null
     await act(async () => {
       result = render(
-        <SmartLink href='http://localhost:6006/favicon.ico' download>{linkText}</SmartLink>
+        <SmartLink href='http://localhost:6006/favicon.ico' download>
+          {linkText}
+        </SmartLink>
       )
     })
     const link = getByRole(result!.container, 'link')
@@ -86,9 +83,7 @@ describe('SmartLink', () => {
   test('it renders tel links correctly', async () => {
     let result: RenderResult | null = null
     await act(async () => {
-      result = render(
-        <SmartLink href='tel:+4733378901'>{linkText}</SmartLink>
-      )
+      result = render(<SmartLink href='tel:+4733378901'>{linkText}</SmartLink>)
     })
     const link = getByRole(result!.container, 'link')
     expect(link).toHaveAttribute('href', 'tel:+4733378901')
@@ -101,7 +96,9 @@ describe('SmartLink', () => {
     let result: RenderResult | null = null
     await act(async () => {
       result = render(
-        <SmartLink href='/home' retainParams>{linkText}</SmartLink>
+        <SmartLink href='/home' retainParams>
+          {linkText}
+        </SmartLink>
       )
     })
     const link = getByRole(result!.container, 'link')
@@ -111,11 +108,13 @@ describe('SmartLink', () => {
     expect(result!.container.firstChild).toMatchSnapshot()
   })
 
-  test('it doesn\'t retain params for external links', async () => {
+  test("it doesn't retain params for external links", async () => {
     let result: RenderResult | null = null
     await act(async () => {
       result = render(
-        <SmartLink href='https://google.com' retainParams>{linkText}</SmartLink>
+        <SmartLink href='https://google.com' retainParams>
+          {linkText}
+        </SmartLink>
       )
     })
     const link = getByRole(result!.container, 'link')
@@ -129,16 +128,24 @@ describe('SmartLink', () => {
     let result: RenderResult | null = null
     await act(async () => {
       result = render(
-        <SmartLink href='/home' params={{
-          test1: ['a', 'b'],
-          test2: [1, 2],
-          test3: 'abc',
-          test4: 123
-        }}>{linkText}</SmartLink>
+        <SmartLink
+          href='/home'
+          params={{
+            test1: ['a', 'b'],
+            test2: [1, 2],
+            test3: 'abc',
+            test4: 123
+          }}
+        >
+          {linkText}
+        </SmartLink>
       )
     })
     const link = getByRole(result!.container, 'link')
-    expect(link).toHaveAttribute('href', '/home?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123')
+    expect(link).toHaveAttribute(
+      'href',
+      '/home?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123'
+    )
     expect(link).not.toHaveAttribute('target')
     expect(link).not.toHaveAttribute('rel')
     expect(result!.container.firstChild).toMatchSnapshot()
@@ -148,16 +155,24 @@ describe('SmartLink', () => {
     let result: RenderResult | null = null
     await act(async () => {
       result = render(
-        <SmartLink href='https://google.com' params={{
-          test1: ['a', 'b'],
-          test2: [1, 2],
-          test3: 'abc',
-          test4: 123
-        }}>{linkText}</SmartLink>
+        <SmartLink
+          href='https://google.com'
+          params={{
+            test1: ['a', 'b'],
+            test2: [1, 2],
+            test3: 'abc',
+            test4: 123
+          }}
+        >
+          {linkText}
+        </SmartLink>
       )
     })
     const link = getByRole(result!.container, 'link')
-    expect(link).toHaveAttribute('href', 'https://google.com?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://google.com?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123'
+    )
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noreferrer noopener')
     expect(result!.container.firstChild).toMatchSnapshot()

--- a/src/components/Link/SmartLink.tsx
+++ b/src/components/Link/SmartLink.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link'
 
 import { appendQueryParams } from '../../utils'
 
-const absoluteUrlRegex = new RegExp('^(?:[a-z]+:)?//', 'i')
+const isAbsoluteUrlRegex = new RegExp('^(?:[a-z]+:)?//', 'i')
+const isMailOrTelUrlRegex = new RegExp('^(mailto|tel):.*', 'i')
 
 // uses next/link for internal page routing
 // uses <a> tag for external page routing
@@ -21,28 +22,25 @@ export function SmartLink({
   const router = useRouter()
   const query = router?.query
 
-  const isInternalLink = useMemo<boolean>(
-    // href can be undefined for a download button
-    () => (!href ? false : !absoluteUrlRegex.test(href)),
+  const isInternalUrl = useMemo<boolean>(
+    () => !isAbsoluteUrlRegex.test(href) && !isMailOrTelUrlRegex.test(href),
     [href]
   )
 
   const hrefWithParams = useMemo<string>(() => {
-    // Ignore params when href is empty or undefined
-    if (!href) return href
     let updatedHref = href
 
     // Add existing query params if retained
-    if (query && isInternalLink && retainParams)
+    if (query && isInternalUrl && retainParams)
       updatedHref = appendQueryParams(updatedHref, query)
 
     // Add new query params if passed
     if (params) updatedHref = appendQueryParams(updatedHref, params)
 
     return updatedHref
-  }, [query, isInternalLink, href, params, retainParams])
+  }, [query, isInternalUrl, href, params, retainParams])
 
-  return isInternalLink ? (
+  return isInternalUrl ? (
     <Link href={hrefWithParams}>
       <a className={className} onClick={onClick}>
         {children}

--- a/src/components/Link/SmartLink.tsx
+++ b/src/components/Link/SmartLink.tsx
@@ -40,7 +40,7 @@ export function SmartLink({
     return updatedHref
   }, [query, isInternalUrl, href, params, retainParams])
 
-  return isInternalUrl ? (
+  return isInternalUrl && !download ? (
     <Link href={hrefWithParams}>
       <a className={className} onClick={onClick}>
         {children}
@@ -48,7 +48,7 @@ export function SmartLink({
     </Link>
   ) : (
     <a
-      target='_blank'
+      target={download ? '_self' : '_blank'}
       rel='noreferrer noopener'
       href={hrefWithParams}
       download={download}

--- a/src/components/Link/SmartLink.tsx
+++ b/src/components/Link/SmartLink.tsx
@@ -64,8 +64,8 @@ export function SmartLink({
 
 export interface SmartLinkProps {
   children: ReactNode
-  href?: string
-  download?: string
+  href: string
+  download?: boolean | string
   className?: string
   params?: Record<string, string | string[] | number | number[]>
   retainParams?: boolean
@@ -77,8 +77,8 @@ export const SmartLinkPropTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
-  href: PropTypes.string,
-  download: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   className: PropTypes.string,
   params: PropTypes.objectOf(
     PropTypes.oneOfType([

--- a/src/components/Link/SmartLink.tsx
+++ b/src/components/Link/SmartLink.tsx
@@ -22,9 +22,13 @@ export function SmartLink({
   const router = useRouter()
   const query = router?.query
 
-  const isInternalUrl = useMemo<boolean>(
-    () => !isAbsoluteUrlRegex.test(href) && !isMailOrTelUrlRegex.test(href),
+  const isMailToOrTelUrl = useMemo<boolean>(
+    () => isMailOrTelUrlRegex.test(href),
     [href]
+  )
+  const isInternalUrl = useMemo<boolean>(
+    () => !isAbsoluteUrlRegex.test(href) && !isMailToOrTelUrl,
+    [href, isMailToOrTelUrl]
   )
 
   const hrefWithParams = useMemo<string>(() => {
@@ -48,7 +52,7 @@ export function SmartLink({
     </Link>
   ) : (
     <a
-      target={download ? '_self' : '_blank'}
+      target={download || isMailToOrTelUrl ? '_self' : '_blank'}
       rel='noreferrer noopener'
       href={hrefWithParams}
       download={download}

--- a/src/components/Link/__snapshots__/SmartLink.test.tsx.snap
+++ b/src/components/Link/__snapshots__/SmartLink.test.tsx.snap
@@ -75,3 +75,23 @@ exports[`SmartLink it renders internal links correctly 1`] = `
   Click me
 </a>
 `;
+
+exports[`SmartLink it renders mailto links correctly 1`] = `
+<a
+  href="mailto:squad@glif.io"
+  rel="noreferrer noopener"
+  target="_self"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it renders tel links correctly 1`] = `
+<a
+  href="tel:+4733378901"
+  rel="noreferrer noopener"
+  target="_self"
+>
+  Click me
+</a>
+`;

--- a/src/components/Link/__snapshots__/SmartLink.test.tsx.snap
+++ b/src/components/Link/__snapshots__/SmartLink.test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SmartLink it can add params to external links 1`] = `
+<a
+  href="https://google.com?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123"
+  rel="noreferrer noopener"
+  target="_blank"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it can add params to internal links 1`] = `
+<a
+  href="/home?test1=a&test1=b&test2=1&test2=2&test3=abc&test4=123"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it can retain params for internal links 1`] = `
+<a
+  href="/home?foo=bar&glif=ftw"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it doesn't retain params for external links 1`] = `
+<a
+  href="https://google.com"
+  rel="noreferrer noopener"
+  target="_blank"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it renders external download links correctly 1`] = `
+<a
+  download=""
+  href="http://localhost:6006/favicon.ico"
+  rel="noreferrer noopener"
+  target="_self"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it renders external links correctly 1`] = `
+<a
+  href="https://google.com"
+  rel="noreferrer noopener"
+  target="_blank"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it renders internal download links correctly 1`] = `
+<a
+  download=""
+  href="/favicon.ico"
+  rel="noreferrer noopener"
+  target="_self"
+>
+  Click me
+</a>
+`;
+
+exports[`SmartLink it renders internal links correctly 1`] = `
+<a
+  href="/home"
+>
+  Click me
+</a>
+`;


### PR DESCRIPTION
While updating the tests in wallet I noticed that some things were not yet working properly with the SmartLink.
`href` should be mandatory, I thought initially that it wasn't required when passing a download attribute, but it still is.
Also some cases for mailto / tel links weren'te working properly.
I've now also added some tests and snapshots to ensure all cases work properly, also with retaining and adding query params 