### PR TITLE
Refactor update

### DIFF
--- a/src/components/AccountCardAlt/__snapshots__/index.test.jsx.snap
+++ b/src/components/AccountCardAlt/__snapshots__/index.test.jsx.snap
@@ -105,7 +105,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
   font-size: 1.5rem;
 }
 
-.c11 {
+.c10 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--purple-medium);
@@ -119,7 +119,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
   align-items: center;
 }
 
-.c17 {
+.c16 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -164,7 +164,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
   margin: 0;
 }
 
-.c18 {
+.c17 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -173,7 +173,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
   margin-bottom: 0;
 }
 
-.c19 {
+.c18 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -192,16 +192,16 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
   border-radius: 4px;
 }
 
-.c19:hover {
+.c18:hover {
   opacity: 0.8;
 }
 
-.c14 {
+.c13 {
   width: 24;
   height: 24;
 }
 
-.c13 {
+.c12 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -226,38 +226,41 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
   outline: none;
 }
 
-.c16 {
+.c15 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c12:hover .c15 {
+.c11:hover .c14 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c10 {
+.c9 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c9 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c9 .address a {
   color: var(--purple-medium);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c10:hover {
+.c9 .address a:hover {
   color: var(--purple-medium);
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
-  grid-gap: 0.25em;
 }
 
 <div
@@ -318,12 +321,14 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
     display="flex"
     font-size="4"
   >
-    <div>
+    <div
+      class="c9"
+      color="var(--purple-medium)"
+    >
       <div
-        class="c9"
+        class="address"
       >
         <a
-          class="c10"
           href="https://explorer-calibration.glif.link/actor/?address=t0123456789"
           rel="noreferrer noopener"
           target="_blank"
@@ -331,18 +336,18 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
           t0123456789
         </a>
         <div
-          class="c11"
+          class="c10"
           color="var(--purple-medium)"
           display="flex"
         >
           <button
-            class="c12 c13"
+            class="c11 c12"
             display="flex"
             role="button"
             type="button"
           >
             <svg
-              class="c14 c15 c16"
+              class="c13 c14 c15"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -370,7 +375,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
     </div>
   </div>
   <div
-    class="c17"
+    class="c16"
     display="flex"
   >
     <div
@@ -378,7 +383,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
       display="flex"
     >
       <p
-        class="c18"
+        class="c17"
         font-family="RT-Alias-Grotesk"
         font-size="3"
         font-weight="400"
@@ -396,7 +401,7 @@ exports[`AccountCardAlt renders created address at random index 1`] = `
       </h2>
     </div>
     <button
-      class="c19"
+      class="c18"
       font-size="3"
       height="6"
       type="button"
@@ -512,7 +517,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
   font-size: 1.5rem;
 }
 
-.c12 {
+.c11 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--purple-medium);
@@ -526,7 +531,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
   align-items: center;
 }
 
-.c18 {
+.c17 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -581,7 +586,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
   margin: 0;
 }
 
-.c19 {
+.c18 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -590,7 +595,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
   margin-bottom: 0;
 }
 
-.c20 {
+.c19 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -609,16 +614,16 @@ exports[`AccountCardAlt renders legacy address 1`] = `
   border-radius: 4px;
 }
 
-.c20:hover {
+.c19:hover {
   opacity: 0.8;
 }
 
-.c15 {
+.c14 {
   width: 24;
   height: 24;
 }
 
-.c14 {
+.c13 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -643,38 +648,41 @@ exports[`AccountCardAlt renders legacy address 1`] = `
   outline: none;
 }
 
-.c17 {
+.c16 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c13:hover .c16 {
+.c12:hover .c15 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c11 {
+.c10 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c10 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c10 .address a {
   color: var(--purple-medium);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c11:hover {
+.c10 .address a:hover {
   color: var(--purple-medium);
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
-  grid-gap: 0.25em;
 }
 
 <div
@@ -746,12 +754,14 @@ exports[`AccountCardAlt renders legacy address 1`] = `
     display="flex"
     font-size="4"
   >
-    <div>
+    <div
+      class="c10"
+      color="var(--purple-medium)"
+    >
       <div
-        class="c10"
+        class="address"
       >
         <a
-          class="c11"
           href="https://explorer-calibration.glif.link/actor/?address=t0123456789"
           rel="noreferrer noopener"
           target="_blank"
@@ -759,18 +769,18 @@ exports[`AccountCardAlt renders legacy address 1`] = `
           t0123456789
         </a>
         <div
-          class="c12"
+          class="c11"
           color="var(--purple-medium)"
           display="flex"
         >
           <button
-            class="c13 c14"
+            class="c12 c13"
             display="flex"
             role="button"
             type="button"
           >
             <svg
-              class="c15 c16 c17"
+              class="c14 c15 c16"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -798,7 +808,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
     </div>
   </div>
   <div
-    class="c18"
+    class="c17"
     display="flex"
   >
     <div
@@ -806,7 +816,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
       display="flex"
     >
       <p
-        class="c19"
+        class="c18"
         font-family="RT-Alias-Grotesk"
         font-size="3"
         font-weight="400"
@@ -824,7 +834,7 @@ exports[`AccountCardAlt renders legacy address 1`] = `
       </h2>
     </div>
     <button
-      class="c20"
+      class="c19"
       font-size="3"
       height="6"
       type="button"
@@ -940,7 +950,7 @@ exports[`AccountCardAlt renders the card 1`] = `
   font-size: 1.5rem;
 }
 
-.c10 {
+.c9 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--white);
@@ -954,7 +964,7 @@ exports[`AccountCardAlt renders the card 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -990,7 +1000,7 @@ exports[`AccountCardAlt renders the card 1`] = `
   margin-bottom: 0;
 }
 
-.c17 {
+.c16 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -999,7 +1009,7 @@ exports[`AccountCardAlt renders the card 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c17 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -1018,16 +1028,16 @@ exports[`AccountCardAlt renders the card 1`] = `
   border-radius: 4px;
 }
 
-.c18:hover {
+.c17:hover {
   opacity: 0.8;
 }
 
-.c13 {
+.c12 {
   width: 24;
   height: 24;
 }
 
-.c12 {
+.c11 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -1052,38 +1062,41 @@ exports[`AccountCardAlt renders the card 1`] = `
   outline: none;
 }
 
-.c15 {
+.c14 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c11:hover .c14 {
+.c10:hover .c13 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c9 {
+.c8 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c8 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c8 .address a {
   color: var(--white);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c9:hover {
+.c8 .address a:hover {
   color: var(--white);
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
-  grid-gap: 0.25em;
 }
 
 <div
@@ -1134,12 +1147,14 @@ exports[`AccountCardAlt renders the card 1`] = `
     display="flex"
     font-size="4"
   >
-    <div>
+    <div
+      class="c8"
+      color="var(--white)"
+    >
       <div
-        class="c8"
+        class="address"
       >
         <a
-          class="c9"
           href="https://explorer-calibration.glif.link/actor/?address=t0123456789"
           rel="noreferrer noopener"
           target="_blank"
@@ -1147,18 +1162,18 @@ exports[`AccountCardAlt renders the card 1`] = `
           t0123456789
         </a>
         <div
-          class="c10"
+          class="c9"
           color="var(--white)"
           display="flex"
         >
           <button
-            class="c11 c12"
+            class="c10 c11"
             display="flex"
             role="button"
             type="button"
           >
             <svg
-              class="c13 c14 c15"
+              class="c12 c13 c14"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1186,7 +1201,7 @@ exports[`AccountCardAlt renders the card 1`] = `
     </div>
   </div>
   <div
-    class="c16"
+    class="c15"
     display="flex"
   >
     <div
@@ -1194,7 +1209,7 @@ exports[`AccountCardAlt renders the card 1`] = `
       display="flex"
     >
       <p
-        class="c17"
+        class="c16"
         font-family="RT-Alias-Grotesk"
         font-size="3"
         font-weight="400"
@@ -1212,7 +1227,7 @@ exports[`AccountCardAlt renders the card 1`] = `
       </h2>
     </div>
     <button
-      class="c18"
+      class="c17"
       font-size="3"
       height="6"
       type="button"
@@ -1328,7 +1343,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
   font-size: 1.5rem;
 }
 
-.c10 {
+.c9 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--purple-medium);
@@ -1342,7 +1357,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1378,7 +1393,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
   margin-bottom: 0;
 }
 
-.c17 {
+.c16 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -1387,7 +1402,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c17 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -1406,16 +1421,16 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
   border-radius: 4px;
 }
 
-.c18:hover {
+.c17:hover {
   opacity: 0.8;
 }
 
-.c13 {
+.c12 {
   width: 24;
   height: 24;
 }
 
-.c12 {
+.c11 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -1440,38 +1455,41 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
   outline: none;
 }
 
-.c15 {
+.c14 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c11:hover .c14 {
+.c10:hover .c13 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c9 {
+.c8 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c8 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c8 .address a {
   color: var(--purple-medium);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c9:hover {
+.c8 .address a:hover {
   color: var(--purple-medium);
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
-  grid-gap: 0.25em;
 }
 
 <div
@@ -1522,12 +1540,14 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
     display="flex"
     font-size="4"
   >
-    <div>
+    <div
+      class="c8"
+      color="var(--purple-medium)"
+    >
       <div
-        class="c8"
+        class="address"
       >
         <a
-          class="c9"
           href="https://explorer-calibration.glif.link/actor/?address=t0123456789"
           rel="noreferrer noopener"
           target="_blank"
@@ -1535,18 +1555,18 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
           t0123456789
         </a>
         <div
-          class="c10"
+          class="c9"
           color="var(--purple-medium)"
           display="flex"
         >
           <button
-            class="c11 c12"
+            class="c10 c11"
             display="flex"
             role="button"
             type="button"
           >
             <svg
-              class="c13 c14 c15"
+              class="c12 c13 c14"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1574,7 +1594,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
     </div>
   </div>
   <div
-    class="c16"
+    class="c15"
     display="flex"
   >
     <div
@@ -1582,7 +1602,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
       display="flex"
     >
       <p
-        class="c17"
+        class="c16"
         font-family="RT-Alias-Grotesk"
         font-size="3"
         font-weight="400"
@@ -1600,7 +1620,7 @@ exports[`AccountCardAlt renders the unselected card 1`] = `
       </h2>
     </div>
     <button
-      class="c18"
+      class="c17"
       font-size="3"
       height="6"
       type="button"

--- a/src/components/AccountSelector/__snapshots__/index.test.js.snap
+++ b/src/components/AccountSelector/__snapshots__/index.test.js.snap
@@ -245,7 +245,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   font-size: 1.5rem;
 }
 
-.c19 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--white);
@@ -259,7 +259,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   align-items: center;
 }
 
-.c25 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -279,7 +279,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   align-items: flex-end;
 }
 
-.c28 {
+.c27 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -304,7 +304,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -328,7 +328,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   justify-content: center;
 }
 
-.c31 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--purple-medium);
@@ -342,7 +342,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   align-items: center;
 }
 
-.c33 {
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -371,12 +371,12 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   justify-content: space-between;
 }
 
-.c35 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c36 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -396,7 +396,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   justify-content: center;
 }
 
-.c40 {
+.c39 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -409,7 +409,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   justify-content: flex-start;
 }
 
-.c44 {
+.c43 {
   min-width: 0;
   box-sizing: border-box;
   width: 100%;
@@ -452,7 +452,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   margin-bottom: 0;
 }
 
-.c34 {
+.c33 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -477,7 +477,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   margin-top: 8px;
 }
 
-.c26 {
+.c25 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -486,7 +486,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   margin-bottom: 0;
 }
 
-.c43 {
+.c42 {
   font-size: 15px;
   font-weight: 400;
   line-height: 1.4;
@@ -497,7 +497,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   margin-top: 4px;
 }
 
-.c37 {
+.c36 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1;
@@ -506,7 +506,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   margin: 0;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -525,11 +525,11 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   border-radius: 4px;
 }
 
-.c27:hover {
+.c26:hover {
   opacity: 0.8;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -548,16 +548,16 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   border-radius: 4px;
 }
 
-.c32:hover {
+.c31:hover {
   opacity: 0.8;
 }
 
-.c22 {
+.c21 {
   width: 24;
   height: 24;
 }
 
-.c21 {
+.c20 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -582,50 +582,67 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   outline: none;
 }
 
-.c24 {
+.c23 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c20:hover .c23 {
+.c19:hover .c22 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c18 {
-  color: var(--white);
-  -webkit-text-decoration: none;
-  text-decoration: none;
+.c17 h4 {
+  margin: 0;
+  color: var(--gray-dark);
 }
 
-.c18:hover {
-  color: var(--white);
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c30 {
-  color: var(--purple-medium);
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c30:hover {
-  color: var(--purple-medium);
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c17 {
+.c17 .address {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
   grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c17 .address a {
+  color: var(--white);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17 .address a:hover {
+  color: var(--white);
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c29 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c29 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c29 .address a {
+  color: var(--purple-medium);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c29 .address a:hover {
+  color: var(--purple-medium);
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c8 {
@@ -643,13 +660,55 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   border-bottom: 2px solid #5E26FF;
 }
 
-.c41 {
+.c40 {
   background: #1AD08F;
   -webkit-transition: 0.2s ease-in-out;
   transition: 0.2s ease-in-out;
   outline: none;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
+  border: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  font-family: RT-Alias-Grotesk;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 50%;
+  height: 48px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c40:hover {
+  -webkit-transform: translateY(-4px);
+  -ms-transform: translateY(-4px);
+  transform: translateY(-4px);
+  cursor: pointer;
+  background: props.theme.colors.input.background.valid;
+}
+
+.c41 {
+  background: #E4EBFC;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  outline: none;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
   border: 0;
   font-size: 1rem;
   font-weight: 400;
@@ -685,49 +744,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   background: props.theme.colors.input.background.valid;
 }
 
-.c42 {
-  background: #E4EBFC;
-  -webkit-transition: 0.2s ease-in-out;
-  transition: 0.2s ease-in-out;
-  outline: none;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  border: 0;
-  font-size: 1rem;
-  font-weight: 400;
-  font-family: RT-Alias-Grotesk;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 50%;
-  height: 48px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-.c42:hover {
-  -webkit-transform: translateY(-4px);
-  -ms-transform: translateY(-4px);
-  transform: translateY(-4px);
-  cursor: pointer;
-  background: props.theme.colors.input.background.valid;
-}
-
-.c38 {
+.c37 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -750,23 +767,23 @@ exports[`AccountSelector it renders the wallets in state with the title and help
   border-color: #999999;
 }
 
-.c38:hover {
+.c37:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c38:focus {
+.c37:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c39 {
+.c38 {
   -moz-appearance: textfield;
 }
 
-.c39::-webkit-outer-spin-button,
-.c39::-webkit-inner-spin-button {
+.c38::-webkit-outer-spin-button,
+.c38::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -890,12 +907,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c17"
+          color="var(--white)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c18"
               href="https://explorer-calibration.glif.link/actor/?address=t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
               rel="noreferrer noopener"
               target="_blank"
@@ -903,18 +922,18 @@ exports[`AccountSelector it renders the wallets in state with the title and help
               t1z225 ... 6z6wgi
             </a>
             <div
-              class="c19"
+              class="c18"
               color="var(--white)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -942,7 +961,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -950,7 +969,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -968,7 +987,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           </h2>
         </div>
         <button
-          class="c27"
+          class="c26"
           font-size="3"
           height="6"
           type="button"
@@ -978,7 +997,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -990,7 +1009,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -1025,12 +1044,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb1uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -1038,18 +1059,18 @@ exports[`AccountSelector it renders the wallets in state with the title and help
               t1mbk7 ... icb1uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -1077,7 +1098,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -1085,7 +1106,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -1103,7 +1124,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -1113,7 +1134,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -1125,7 +1146,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -1160,12 +1181,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb2uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -1173,18 +1196,18 @@ exports[`AccountSelector it renders the wallets in state with the title and help
               t1mbk7 ... icb2uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -1212,7 +1235,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -1220,7 +1243,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -1238,7 +1261,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -1248,7 +1271,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -1260,7 +1283,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -1295,12 +1318,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb3uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -1308,18 +1333,18 @@ exports[`AccountSelector it renders the wallets in state with the title and help
               t1mbk7 ... icb3uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -1347,7 +1372,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -1355,7 +1380,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -1373,7 +1398,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -1383,7 +1408,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -1395,7 +1420,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -1430,12 +1455,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb4uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -1443,18 +1470,18 @@ exports[`AccountSelector it renders the wallets in state with the title and help
               t1mbk7 ... icb4uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -1482,7 +1509,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -1490,7 +1517,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -1508,7 +1535,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -1518,7 +1545,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
       </div>
     </div>
     <div
-      class="c33"
+      class="c32"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -1526,7 +1553,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
       width="100%"
     >
       <h2
-        class="c34"
+        class="c33"
         font-family="RT-Alias-Grotesk"
         font-size="4"
         font-weight="400"
@@ -1534,14 +1561,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         Create new account
       </h2>
       <div
-        class="c35"
+        class="c34"
       >
         <div
-          class="c36"
+          class="c35"
           display="flex"
         >
           <h4
-            class="c37"
+            class="c36"
             font-family="RT-Alias-Grotesk"
             font-size="2"
             font-weight="400"
@@ -1550,7 +1577,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
             Account index
           </h4>
           <input
-            class="c38 c39"
+            class="c37 c38"
             display="inline-block"
             height="6"
             value="5"
@@ -1560,14 +1587,14 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         
       </div>
       <div
-        class="c35"
+        class="c34"
       >
         <div
-          class="c40"
+          class="c39"
           display="flex"
         >
           <button
-            class="c41"
+            class="c40"
             display="flex"
             font-family="RT-Alias-Grotesk"
             font-size="1"
@@ -1578,7 +1605,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
             Legacy address
           </button>
           <button
-            class="c42"
+            class="c41"
             display="flex"
             font-family="RT-Alias-Grotesk"
             font-size="1"
@@ -1590,7 +1617,7 @@ exports[`AccountSelector it renders the wallets in state with the title and help
           </button>
         </div>
         <p
-          class="c43"
+          class="c42"
           font-family="RT-Alias-Grotesk"
           font-size="15px"
           font-weight="400"
@@ -1599,12 +1626,12 @@ exports[`AccountSelector it renders the wallets in state with the title and help
         </p>
       </div>
       <div
-        class="c44"
+        class="c43"
         display="flex"
         width="100%"
       >
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -1780,7 +1807,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   font-size: 1.5rem;
 }
 
-.c19 {
+.c18 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--white);
@@ -1794,7 +1821,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   align-items: center;
 }
 
-.c25 {
+.c24 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1814,7 +1841,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   align-items: flex-end;
 }
 
-.c28 {
+.c27 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -1839,7 +1866,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   min-width: 0;
   box-sizing: border-box;
   border-width: 0.1875rem;
@@ -1863,7 +1890,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   justify-content: center;
 }
 
-.c31 {
+.c30 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--purple-medium);
@@ -1877,7 +1904,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   align-items: center;
 }
 
-.c33 {
+.c32 {
   min-width: 0;
   box-sizing: border-box;
   border: 1px solid;
@@ -1906,12 +1933,12 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   justify-content: space-between;
 }
 
-.c35 {
+.c34 {
   min-width: 0;
   box-sizing: border-box;
 }
 
-.c36 {
+.c35 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1931,7 +1958,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   justify-content: center;
 }
 
-.c40 {
+.c39 {
   min-width: 0;
   box-sizing: border-box;
   display: -webkit-box;
@@ -1944,7 +1971,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   justify-content: flex-start;
 }
 
-.c44 {
+.c43 {
   min-width: 0;
   box-sizing: border-box;
   width: 100%;
@@ -1987,7 +2014,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   margin-bottom: 0;
 }
 
-.c34 {
+.c33 {
   font-size: 1.5rem;
   font-weight: 400;
   line-height: 1.2;
@@ -2012,7 +2039,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   margin-top: 8px;
 }
 
-.c26 {
+.c25 {
   font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.4;
@@ -2021,7 +2048,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   margin-bottom: 0;
 }
 
-.c43 {
+.c42 {
   font-size: 15px;
   font-weight: 400;
   line-height: 1.4;
@@ -2032,7 +2059,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   margin-top: 4px;
 }
 
-.c37 {
+.c36 {
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1;
@@ -2041,7 +2068,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   margin: 0;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
   border: 1px solid #E0D7FE;
   background-color: transparent;
@@ -2060,11 +2087,11 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   border-radius: 4px;
 }
 
-.c27:hover {
+.c26:hover {
   opacity: 0.8;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   border: 1px solid #262626;
   background-color: transparent;
@@ -2083,16 +2110,16 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   border-radius: 4px;
 }
 
-.c32:hover {
+.c31:hover {
   opacity: 0.8;
 }
 
-.c22 {
+.c21 {
   width: 24;
   height: 24;
 }
 
-.c21 {
+.c20 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -2117,50 +2144,67 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   outline: none;
 }
 
-.c24 {
+.c23 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c20:hover .c23 {
+.c19:hover .c22 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c18 {
-  color: var(--white);
-  -webkit-text-decoration: none;
-  text-decoration: none;
+.c17 h4 {
+  margin: 0;
+  color: var(--gray-dark);
 }
 
-.c18:hover {
-  color: var(--white);
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c30 {
-  color: var(--purple-medium);
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c30:hover {
-  color: var(--purple-medium);
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c17 {
+.c17 .address {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
   grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c17 .address a {
+  color: var(--white);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17 .address a:hover {
+  color: var(--white);
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c29 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c29 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c29 .address a {
+  color: var(--purple-medium);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c29 .address a:hover {
+  color: var(--purple-medium);
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c8 {
@@ -2178,13 +2222,55 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   border-bottom: 2px solid #5E26FF;
 }
 
-.c41 {
+.c40 {
   background: #1AD08F;
   -webkit-transition: 0.2s ease-in-out;
   transition: 0.2s ease-in-out;
   outline: none;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
+  border: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  font-family: RT-Alias-Grotesk;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 50%;
+  height: 48px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c40:hover {
+  -webkit-transform: translateY(-4px);
+  -ms-transform: translateY(-4px);
+  transform: translateY(-4px);
+  cursor: pointer;
+  background: props.theme.colors.input.background.valid;
+}
+
+.c41 {
+  background: #E4EBFC;
+  -webkit-transition: 0.2s ease-in-out;
+  transition: 0.2s ease-in-out;
+  outline: none;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
   border: 0;
   font-size: 1rem;
   font-weight: 400;
@@ -2220,49 +2306,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   background: props.theme.colors.input.background.valid;
 }
 
-.c42 {
-  background: #E4EBFC;
-  -webkit-transition: 0.2s ease-in-out;
-  transition: 0.2s ease-in-out;
-  outline: none;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  border: 0;
-  font-size: 1rem;
-  font-weight: 400;
-  font-family: RT-Alias-Grotesk;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 50%;
-  height: 48px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-.c42:hover {
-  -webkit-transform: translateY(-4px);
-  -ms-transform: translateY(-4px);
-  transform: translateY(-4px);
-  cursor: pointer;
-  background: props.theme.colors.input.background.valid;
-}
-
-.c38 {
+.c37 {
   min-width: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -2285,23 +2329,23 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
   border-color: #999999;
 }
 
-.c38:hover {
+.c37:hover {
   background: #bacbf7;
   cursor: text;
 }
 
-.c38:focus {
+.c37:focus {
   box-shadow: 0;
   outline: 0;
   background: #bacbf7;
 }
 
-.c39 {
+.c38 {
   -moz-appearance: textfield;
 }
 
-.c39::-webkit-outer-spin-button,
-.c39::-webkit-inner-spin-button {
+.c38::-webkit-outer-spin-button,
+.c38::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
@@ -2425,12 +2469,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c17"
+          color="var(--white)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c18"
               href="https://explorer-calibration.glif.link/actor/?address=t1z225tguggx4onbauimqvxzutopzdr2m4s6z6wgi"
               rel="noreferrer noopener"
               target="_blank"
@@ -2438,18 +2484,18 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
               t1z225 ... 6z6wgi
             </a>
             <div
-              class="c19"
+              class="c18"
               color="var(--white)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -2477,7 +2523,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -2485,7 +2531,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -2503,7 +2549,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           </h2>
         </div>
         <button
-          class="c27"
+          class="c26"
           font-size="3"
           height="6"
           type="button"
@@ -2513,7 +2559,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -2525,7 +2571,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -2560,12 +2606,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb1uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -2573,18 +2621,18 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
               t1mbk7 ... icb1uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -2612,7 +2660,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -2620,7 +2668,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -2638,7 +2686,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -2648,7 +2696,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -2660,7 +2708,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -2695,12 +2743,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb2uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -2708,18 +2758,18 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
               t1mbk7 ... icb2uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -2747,7 +2797,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -2755,7 +2805,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -2773,7 +2823,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -2783,7 +2833,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -2795,7 +2845,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -2830,12 +2880,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb3uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -2843,18 +2895,18 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
               t1mbk7 ... icb3uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -2882,7 +2934,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -2890,7 +2942,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -2908,7 +2960,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -2918,7 +2970,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
       </div>
     </div>
     <div
-      class="c28"
+      class="c27"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -2930,7 +2982,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
       >
         <div
-          class="c29"
+          class="c28"
           color="colors.core.black"
           display="flex"
           size="6"
@@ -2965,12 +3017,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         display="flex"
         font-size="4"
       >
-        <div>
+        <div
+          class="c29"
+          color="var(--purple-medium)"
+        >
           <div
-            class="c17"
+            class="address"
           >
             <a
-              class="c30"
               href="https://explorer-calibration.glif.link/actor/?address=t1mbk7q6gm4rjlndfqw6f2vkfgqotres3fgicb4uq"
               rel="noreferrer noopener"
               target="_blank"
@@ -2978,18 +3032,18 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
               t1mbk7 ... icb4uq
             </a>
             <div
-              class="c31"
+              class="c30"
               color="var(--purple-medium)"
               display="flex"
             >
               <button
-                class="c20 c21"
+                class="c19 c20"
                 display="flex"
                 role="button"
                 type="button"
               >
                 <svg
-                  class="c22 c23 c24"
+                  class="c21 c22 c23"
                   fill="none"
                   height="24"
                   viewBox="0 0 24 24"
@@ -3017,7 +3071,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         </div>
       </div>
       <div
-        class="c25"
+        class="c24"
         display="flex"
       >
         <div
@@ -3025,7 +3079,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           display="flex"
         >
           <p
-            class="c26"
+            class="c25"
             font-family="RT-Alias-Grotesk"
             font-size="3"
             font-weight="400"
@@ -3043,7 +3097,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           </h2>
         </div>
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"
@@ -3053,7 +3107,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
       </div>
     </div>
     <div
-      class="c33"
+      class="c32"
       color="colors.core.black"
       display="flex"
       height="11"
@@ -3061,7 +3115,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
       width="100%"
     >
       <h2
-        class="c34"
+        class="c33"
         font-family="RT-Alias-Grotesk"
         font-size="4"
         font-weight="400"
@@ -3069,14 +3123,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         Create new account
       </h2>
       <div
-        class="c35"
+        class="c34"
       >
         <div
-          class="c36"
+          class="c35"
           display="flex"
         >
           <h4
-            class="c37"
+            class="c36"
             font-family="RT-Alias-Grotesk"
             font-size="2"
             font-weight="400"
@@ -3085,7 +3139,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
             Account index
           </h4>
           <input
-            class="c38 c39"
+            class="c37 c38"
             display="inline-block"
             height="6"
             value="5"
@@ -3095,14 +3149,14 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         
       </div>
       <div
-        class="c35"
+        class="c34"
       >
         <div
-          class="c40"
+          class="c39"
           display="flex"
         >
           <button
-            class="c41"
+            class="c40"
             display="flex"
             font-family="RT-Alias-Grotesk"
             font-size="1"
@@ -3113,7 +3167,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
             Legacy address
           </button>
           <button
-            class="c42"
+            class="c41"
             display="flex"
             font-family="RT-Alias-Grotesk"
             font-size="1"
@@ -3125,7 +3179,7 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
           </button>
         </div>
         <p
-          class="c43"
+          class="c42"
           font-family="RT-Alias-Grotesk"
           font-size="15px"
           font-weight="400"
@@ -3134,12 +3188,12 @@ exports[`AccountSelector it renders the wallets in state, and an option to creat
         </p>
       </div>
       <div
-        class="c44"
+        class="c43"
         display="flex"
         width="100%"
       >
         <button
-          class="c32"
+          class="c31"
           font-size="3"
           height="6"
           type="button"

--- a/src/components/AddressLink/__snapshots__/index.test.jsx.snap
+++ b/src/components/AddressLink/__snapshots__/index.test.jsx.snap
@@ -1,16 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Receive it renders correctly 1`] = `
-.c0 {
-  color: #666666;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1;
-  font-family: RT-Alias-Grotesk;
-  margin: 0;
-}
-
-.c3 {
+.c1 {
   min-width: 0;
   box-sizing: border-box;
   color: var(--purple-medium);
@@ -24,12 +15,12 @@ exports[`Receive it renders correctly 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c4 {
   width: 24;
   height: 24;
 }
 
-.c5 {
+.c3 {
   height: auto;
   cursor: pointer;
   opacity: 1;
@@ -54,55 +45,54 @@ exports[`Receive it renders correctly 1`] = `
   outline: none;
 }
 
-.c8 {
+.c6 {
   -webkit-transition: 0.24s ease-in-out;
   transition: 0.24s ease-in-out;
 }
 
-.c4:hover .c7 {
+.c2:hover .c5 {
   -webkit-transform: scale(1.25);
   -ms-transform: scale(1.25);
   transform: scale(1.25);
 }
 
-.c2 {
+.c0 h4 {
+  margin: 0;
+  color: var(--gray-dark);
+}
+
+.c0 .address {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-gap: 0.25em;
+  line-height: 1.5;
+}
+
+.c0 .address a {
   color: var(--purple-medium);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c2:hover {
+.c0 .address a:hover {
   color: var(--purple-medium);
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flexdirection: row;
-  -ms-flexdirection: row;
-  flexdirection: row;
-  grid-gap: 0.25em;
-}
-
-<div>
-  <h4
-    class="c0"
-    color="core.darkgray"
-    font-family="RT-Alias-Grotesk"
-    font-size="1"
-    font-weight="400"
-  >
+<div
+  class="c0"
+  color="var(--purple-medium)"
+>
+  <h4>
     Safe Address
   </h4>
   <div
-    class="c1"
+    class="address"
   >
     <a
-      class="c2"
       href="https://explorer-calibration.glif.link/actor/?address=t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy"
       rel="noreferrer noopener"
       target="_blank"
@@ -110,18 +100,18 @@ exports[`Receive it renders correctly 1`] = `
       t137sj ... 2vizpy
     </a>
     <div
-      class="c3"
+      class="c1"
       color="var(--purple-medium)"
       display="flex"
     >
       <button
-        class="c4 c5"
+        class="c2 c3"
         display="flex"
         role="button"
         type="button"
       >
         <svg
-          class="c6 c7 c8"
+          class="c4 c5 c6"
           fill="none"
           height="24"
           viewBox="0 0 24 24"

--- a/src/components/AddressLink/index.tsx
+++ b/src/components/AddressLink/index.tsx
@@ -1,28 +1,30 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, MouseEvent } from 'react'
 import truncateAddress from '../../utils/truncateAddress'
 import { SmartLink } from '../Link/SmartLink'
 import { CopyText } from '../Copy'
 
-const Label = styled.h4`
-  margin: 0;
-  color: var(--gray-dark);
-`
-
-const Link = styled(SmartLink)`
-  color: ${props => props.color};
-  text-decoration: none;
-  &:hover {
-    color: ${props => props.color};
-    text-decoration: underline;
+const AddressLinkEl = styled.div`
+  h4 {
+    margin: 0;
+    color: var(--gray-dark);
   }
-`
 
-const AddressWrap = styled.div`
-  display: flex;
-  grid-gap: 0.25em;
-  line-height: 1.5;
+  .address {
+    display: flex;
+    grid-gap: 0.25em;
+    line-height: 1.5;
+
+    a {
+      color: ${props => props.color};
+      text-decoration: none;
+      &:hover {
+        color: ${props => props.color};
+        text-decoration: underline;
+      }
+    }
+  }
 `
 
 const explorerUrl =
@@ -49,19 +51,20 @@ export const AddressLink = ({
 
   const linkHref = `${explorerUrl}/actor/?address=${address || id}`
   const onClick = useCallback(
-    (e: MouseEvent) => stopPropagation && e.stopPropagation(),
+    (e: MouseEvent<HTMLAnchorElement>) =>
+      stopPropagation && e.stopPropagation(),
     [stopPropagation]
   )
   return (
-    <div>
-      {label && <Label>{label}</Label>}
-      <AddressWrap>
+    <AddressLinkEl color={color}>
+      {label && <h4>{label}</h4>}
+      <div className='address'>
         {disableLink ? (
           <span>{linkText}</span>
         ) : (
-          <Link color={color} href={linkHref} onClick={onClick}>
+          <SmartLink href={linkHref} onClick={onClick}>
             {linkText}
-          </Link>
+          </SmartLink>
         )}
         {!hideCopy && (address || id) && (
           <CopyText
@@ -70,8 +73,8 @@ export const AddressLink = ({
             color={color}
           />
         )}
-      </AddressWrap>
-    </div>
+      </div>
+    </AddressLinkEl>
   )
 }
 

--- a/src/components/AddressLink/index.tsx
+++ b/src/components/AddressLink/index.tsx
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types'
 import { useMemo, useCallback } from 'react'
 import truncateAddress from '../../utils/truncateAddress'
 import { SmartLink } from '../Link/SmartLink'
-import { Label } from '../Typography'
 import { CopyText } from '../Copy'
+
+const Label = styled.h4`
+  margin: 0;
+  color: var(--gray-dark);
+`
 
 const Link = styled(SmartLink)`
   color: ${props => props.color};
@@ -51,11 +55,7 @@ export const AddressLink = ({
   )
   return (
     <div>
-      {label && (
-        <Label color='core.darkgray' fontSize={1}>
-          {label}
-        </Label>
-      )}
+      {label && <Label>{label}</Label>}
       <AddressWrap hideCopy={hideCopy}>
         {disableLink ? (
           <span>{linkText}</span>

--- a/src/components/AddressLink/index.tsx
+++ b/src/components/AddressLink/index.tsx
@@ -64,8 +64,12 @@ export const AddressLink = ({
             {linkText}
           </Link>
         )}
-        {!hideCopy && !!linkText && (
-          <CopyText text={address} hideCopyText={hideCopyText} color={color} />
+        {!hideCopy && (address || id) && (
+          <CopyText
+            text={address || id}
+            hideCopyText={hideCopyText}
+            color={color}
+          />
         )}
       </AddressWrap>
     </div>

--- a/src/components/AddressLink/index.tsx
+++ b/src/components/AddressLink/index.tsx
@@ -42,13 +42,10 @@ export const AddressLink = ({
   hideCopyText
 }: AddressLinkProps) => {
   // prioritize robust > id, use id if no robust exists
-  const linkText = useMemo(() => {
-    if (address) return truncateAddress(address)
-    else if (id) return id
-
-    return ''
-  }, [address, id])
-
+  const linkText = useMemo(
+    () => (address ? truncateAddress(address) : id || ''),
+    [address, id]
+  )
   const linkHref = `${explorerUrl}/actor/?address=${address || id}`
   const onClick = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) =>

--- a/src/components/AddressLink/index.tsx
+++ b/src/components/AddressLink/index.tsx
@@ -21,9 +21,8 @@ const Link = styled(SmartLink)`
 
 const AddressWrap = styled.div`
   display: flex;
-  flexdirection: row;
   grid-gap: 0.25em;
-  line-height: ${props => props.hideCopy && '1.5'};
+  line-height: 1.5;
 `
 
 const explorerUrl =
@@ -56,7 +55,7 @@ export const AddressLink = ({
   return (
     <div>
       {label && <Label>{label}</Label>}
-      <AddressWrap hideCopy={hideCopy}>
+      <AddressWrap>
         {disableLink ? (
           <span>{linkText}</span>
         ) : (

--- a/src/components/HistoryTables/MessageHistory/Detail.tsx
+++ b/src/components/HistoryTables/MessageHistory/Detail.tsx
@@ -51,12 +51,10 @@ export default function MessageDetail(props: MessageDetailProps) {
     [message?.value]
   )
   const totalCost = useMemo(() => {
-    if (!message) return ''
     const cost = (message as Message)?.gasCost?.totalCost
-    if (!cost) return ''
-    return `${makeFriendlyBalance(
-      new FilecoinNumber((message as Message)?.gasCost?.totalCost, 'attofil')
-    )} FIL`
+    return cost
+      ? `${makeFriendlyBalance(new FilecoinNumber(cost, 'attofil'))} FIL`
+      : ''
   }, [message])
 
   const gasPercentage = useMemo(

--- a/src/components/HistoryTables/MessageHistory/Detail.tsx
+++ b/src/components/HistoryTables/MessageHistory/Detail.tsx
@@ -46,22 +46,22 @@ export default function MessageDetail(props: MessageDetailProps) {
     skip: pending
   })
 
-  const value = useMemo(
+  const value = useMemo<string>(
     () => (message?.value ? attoFilToFil(message.value) : ''),
     [message?.value]
   )
-  const totalCost = useMemo(() => {
+  const totalCost = useMemo<string>(() => {
     const cost = (message as Message)?.gasCost?.totalCost
     return cost
       ? `${makeFriendlyBalance(new FilecoinNumber(cost, 'attofil'))} FIL`
       : ''
   }, [message])
 
-  const gasPercentage = useMemo(
+  const gasPercentage = useMemo<string>(
     () => (message ? getGasPercentage(message, pending) : ''),
     [message, pending]
   )
-  const gasBurned = useMemo(() => {
+  const gasBurned = useMemo<string>(() => {
     if (!message || pending) return ''
     const baseFeeBurn = new FilecoinNumber(
       (message as Message)?.gasCost?.baseFeeBurn,
@@ -76,7 +76,7 @@ export default function MessageDetail(props: MessageDetailProps) {
 
   const unformattedTime = useUnformattedDateTime(message, time)
 
-  const confirmationCount = useMemo(
+  const confirmationCount = useMemo<number>(
     () =>
       chainHeadSubscription.data?.chainHead.height && !!message?.height
         ? chainHeadSubscription.data.chainHead.height - Number(message.height)
@@ -86,7 +86,7 @@ export default function MessageDetail(props: MessageDetailProps) {
 
   const { methodName, actorName } = useMethodName(message)
 
-  const execReturn: ExecReturn | null = useMemo(() => {
+  const execReturn = useMemo<ExecReturn | null>(() => {
     if (!message) return null
     // if this is an init message to the exec actor...
     if (isAddrEqual(message.to, 'f01') && Number(message.method) === 2) {

--- a/src/components/HistoryTables/MessageHistory/Detail.tsx
+++ b/src/components/HistoryTables/MessageHistory/Detail.tsx
@@ -86,14 +86,14 @@ export default function MessageDetail(props: MessageDetailProps) {
 
   const { methodName, actorName } = useMethodName(message)
 
-  const execReturn = useMemo<ExecReturn | null>(() => {
-    if (!message) return null
-    // if this is an init message to the exec actor...
-    if (isAddrEqual(message.to, 'f01') && Number(message.method) === 2) {
-      return getAddrFromReceipt((message as Message)?.receipt?.return)
-    }
-    return null
-  }, [message])
+  const execReturn = useMemo<ExecReturn | null>(
+    () =>
+      // if this is an init message to the exec actor...
+      isAddrEqual(message?.to, 'f01') && Number(message?.method) === 2
+        ? getAddrFromReceipt((message as Message)?.receipt?.return)
+        : null,
+    [message]
+  )
 
   return (
     <>

--- a/src/components/HistoryTables/MessageHistory/MessageConfirmedRow.tsx
+++ b/src/components/HistoryTables/MessageHistory/MessageConfirmedRow.tsx
@@ -43,7 +43,7 @@ export default function MessageHistoryRow(props: MessageHistoryRowProps) {
       <TD>{age}</TD>
       <TD>
         <AddressLink
-          id={message.from.robust ? '' : message.from.id}
+          id={message.from.id}
           address={message.from.robust}
           disableLink={fromAddressIsInspecting}
           hideCopy
@@ -59,7 +59,7 @@ export default function MessageHistoryRow(props: MessageHistoryRowProps) {
       )}
       <TD>
         <AddressLink
-          id={message.to.robust ? '' : message.to.id}
+          id={message.to.id}
           address={message.to.robust}
           disableLink={toAddressIsInspecting}
           hideCopy

--- a/src/components/HistoryTables/MessageHistory/MessagePendingRow.tsx
+++ b/src/components/HistoryTables/MessageHistory/MessagePendingRow.tsx
@@ -44,7 +44,7 @@ export default function PendingMessageHistoryRow(
       <TD>(Pending)</TD>
       <TD>
         <AddressLink
-          id={message.from.robust ? '' : message.from.id}
+          id={message.from.id}
           address={message.from.robust}
           disableLink={fromAddressIsInspecting}
           hideCopy
@@ -58,7 +58,7 @@ export default function PendingMessageHistoryRow(
       </TD>
       <TD>
         <AddressLink
-          id={message.to.robust ? '' : message.to.id}
+          id={message.to.id}
           address={message.to.robust}
           disableLink={toAddressIsInspecting}
           hideCopy

--- a/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
+++ b/src/components/HistoryTables/MsigProposals/ProposalRow.tsx
@@ -52,7 +52,7 @@ export default function ProposalHistoryRow(props: ProposalHistoryRowProps) {
       </TD>
       <TD>
         <AddressLink
-          id={proposal.approved[0].robust ? '' : proposal.approved[0].id}
+          id={proposal.approved[0].id}
           address={proposal.approved[0].robust}
           disableLink={proposerIsInspecting}
           hideCopy

--- a/src/components/Link/SmartLink.tsx
+++ b/src/components/Link/SmartLink.tsx
@@ -1,4 +1,4 @@
-import { useMemo, ReactNode } from 'react'
+import { useMemo, ReactNode, MouseEvent } from 'react'
 import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
@@ -71,7 +71,7 @@ export interface SmartLinkProps {
   className?: string
   params?: Record<string, string | string[] | number | number[]>
   retainParams?: boolean
-  onClick?: () => void
+  onClick?: (e: MouseEvent<HTMLAnchorElement>) => void
 }
 
 export const SmartLinkPropTypes = {


### PR DESCRIPTION
Hey, this is just a small tidy up, mainly in AddressLink. I think it's a good aim to just use one styled component per react component. You can easily target elements with custom css and this makes it a lot easier to read in my opinion. Also this removes another styled system component from Typography :)

In some cases we were also explicitly omitting the id for AddressLink to prevent showing them both, which is not necessary anymore.

Also some `useMemo` statements could be written a bit simpler, I think this is more readable as well, but that might be a personal preference.