### PR TITLE
Improve phishing banner

### DIFF
--- a/src/components/PhishingBanner/__snapshots__/index.test.jsx.snap
+++ b/src/components/PhishingBanner/__snapshots__/index.test.jsx.snap
@@ -51,11 +51,11 @@ exports[`Phishing Banner renders the phishing banner 1`] = `
   <p>
     For your protection, please check your browser's URL bar that you're visiting 
     <a
-      href="https://sender.glif.io"
+      href="https://test.glif.io"
       rel="noreferrer noopener"
       target="_blank"
     >
-      https://sender.glif.io
+      https://test.glif.io
     </a>
   </p>
   <button

--- a/src/components/PhishingBanner/index.jsx
+++ b/src/components/PhishingBanner/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useMemo, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { SmartLink } from '../Link/SmartLink'
@@ -41,16 +41,32 @@ const PhishingBannerContainer = styled.div`
 
 export default function PhishingBanner({ href }) {
   const [closed, setClosed] = useState(false)
-  useEffect(() => {
-    if (!href.includes('glif.io')) {
-      logger.error('PHISHING DETECTED')
-    }
-  }, [href])
+  const glifDomain = 'glif.io'
+  const hrefDomain = useMemo(
+    () => new URL(href).hostname.split('.').slice(-2).join('.'),
+    [href]
+  )
+  const isPhishing = useMemo(
+    () => hrefDomain !== glifDomain,
+    [hrefDomain, glifDomain]
+  )
+
+  useEffect(
+    () => isPhishing && logger.error(`PHISHING DETECTED BY ${href}`),
+    [isPhishing, href]
+  )
+
   return (
     <>
       {!closed && (
         <PhishingBannerContainer>
-          {href.includes('glif.io') && (
+          {isPhishing ? (
+            <p>
+              WARNING: Possible phishing detected! This website is not on the{' '}
+              <SmartLink href={`https://${glifDomain}`}>{glifDomain}</SmartLink>{' '}
+              domain.
+            </p>
+          ) : (
             <p>
               For your protection, please check your browser&apos;s URL bar that
               you&apos;re visiting&nbsp;

--- a/src/components/PhishingBanner/index.stories.jsx
+++ b/src/components/PhishingBanner/index.stories.jsx
@@ -1,6 +1,5 @@
 import theme from '../theme'
 import ThemeProvider from '../ThemeProvider'
-
 import PhishingBanner from './index'
 
 export default {
@@ -20,7 +19,10 @@ const Template = args => <PhishingBanner {...args} />
 
 export const Base = Template.bind({})
 Base.args = {
-  href: 'https://sender.glif.io',
-  closed: false,
-  setClosed: () => {}
+  href: 'https://test.glif.io'
+}
+
+export const Phished = Template.bind({})
+Phished.args = {
+  href: 'https://test.glif.io.hacked'
 }


### PR DESCRIPTION
This uses the URL object to ensure that we're checking the actual domain of the passed href and not just whether `glif.io` exists somewhere in the href